### PR TITLE
feat: non-interactive mode, list command and dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ A beautiful, interactive CLI wizard for creating Jira tickets with smart default
 ## ✨ Features
 
 - 🧙‍♂️ **Interactive Wizard**: Step-by-step guided ticket creation
+- 🤖 **Non-Interactive Mode**: Create tickets from scripts and AI agents using flags
 - 🎯 **Smart Defaults**: Suggests active sprints, recent epics, and assignees
 - 🚀 **Quick Creation**: Create tickets based on existing ones
 - 🔄 **Template System**: Copy settings from existing tickets
+- 🔍 **Resource Discovery**: List projects, issue types, priorities, epics, and sprints as JSON
+- 🧪 **Dry Run**: Preview the full payload before creating any ticket
 - 🔒 **Secure**: API token-based authentication
 - 🎨 **Beautiful UI**: Colorful, user-friendly terminal interface
 - ⚡ **Fast Setup**: One-command configuration
@@ -263,6 +266,100 @@ Available priorities:
 ```
 Full interactive wizard for creating tickets from scratch.
 
+### Create Ticket (Non-Interactive)
+
+Skip the wizard entirely by passing flags. Outputs only the issue key to stdout — ideal for scripts and AI agents.
+
+```bash
+./vendor/bin/jira-wizard create \
+  --project=ALDO \
+  --type=Task \
+  --summary="Upgrade bundle X for OroCommerce 6.1" \
+  --description="Check breaking changes in the CHANGELOG" \
+  --epic=ALDO-526 \
+  --labels=upgrade,orocommerce \
+  --priority=High \
+  --sprint=active
+
+# stdout: ALDO-123
+```
+
+**Available flags:**
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--project` | `-p` | Yes | Project key (e.g. `ALDO`) |
+| `--type` | `-t` | Yes | Issue type name (e.g. `Task`, `Story`, `Epic`) |
+| `--summary` | `-s` | Yes | Ticket title |
+| `--description` | `-d` | No | Ticket description |
+| `--parent` | | No | Parent/epic key (e.g. `ALDO-10`) |
+| `--epic` | | No | Alias for `--parent` |
+| `--labels` | `-l` | No | Comma-separated labels (e.g. `upgrade,backend`) |
+| `--priority` | | No | Priority name (e.g. `High`, `Medium`, `Low`) |
+| `--sprint` | | No | Sprint ID or `active` to auto-resolve the current sprint |
+| `--dry-run` | | No | Print the JSON payload without creating the ticket |
+
+**Capture the key in a script:**
+```bash
+KEY=$(./vendor/bin/jira-wizard create --project=ALDO --type=Task --summary="..." --no-interaction)
+echo "Created: $KEY"
+```
+
+**Preview before creating (dry-run):**
+```bash
+./vendor/bin/jira-wizard create \
+  --project=ALDO --type=Task --summary="Test" --sprint=active --dry-run
+```
+
+### List Resources as JSON
+
+Discover valid values for flags before scripting or using with an AI agent:
+
+```bash
+# Show available resource types
+./vendor/bin/jira-wizard list
+
+# List all projects
+./vendor/bin/jira-wizard list projects
+
+# List issue types for a project
+./vendor/bin/jira-wizard list issue-types --project=ALDO
+
+# List priorities
+./vendor/bin/jira-wizard list priorities
+
+# List epics for a project
+./vendor/bin/jira-wizard list epics --project=ALDO
+
+# List active sprint for a project
+./vendor/bin/jira-wizard list sprints --project=ALDO
+```
+
+**Example output (`list projects`):**
+```json
+[
+  {"key": "ALDO", "name": "ALDO - B2B project"},
+  {"key": "SYN",  "name": "Synoproject"}
+]
+```
+
+**Typical AI agent workflow:**
+```bash
+# 1. Discover project key
+PROJECT=$(./vendor/bin/jira-wizard list projects | jq -r '.[] | select(.name | test("ALDO")) | .key')
+
+# 2. Discover epic key
+EPIC=$(./vendor/bin/jira-wizard list epics --project=$PROJECT | jq -r '.[0].key')
+
+# 3. Create ticket
+KEY=$(./vendor/bin/jira-wizard create \
+  --project=$PROJECT --type=Task \
+  --summary="Automated task" --epic=$EPIC --sprint=active \
+  --no-interaction)
+
+echo "Created: $KEY"
+```
+
 ### Create from Template
 ```bash
 ./vendor/bin/jira-wizard create-from <ISSUE-KEY>
@@ -296,6 +393,7 @@ Display current configuration and test connection to Jira.
 ### Get Help
 ```bash
 ./vendor/bin/jira-wizard --help
+./vendor/bin/jira-wizard list --help
 ./vendor/bin/jira-wizard create-from --help
 ```
 
@@ -510,23 +608,24 @@ composer phpstan
 
 ```
 ├── bin/
-│   └── jira-wizard                  # CLI entry point
+│   └── jira-wizard                              # CLI entry point
 ├── src/
 │   ├── Commands/
-│   │   ├── CreateTicketCommand.php  # Main wizard command
-│   │   ├── CreateFromCommand.php    # Template creation command
-│   │   ├── ConfigureCommand.php     # Configuration command
-│   │   └── StatusCommand.php        # Status command
+│   │   ├── CreateTicketCommand.php              # Interactive wizard + non-interactive mode
+│   │   ├── CreateFromCommand.php                # Template creation command
+│   │   ├── ListCommand.php                      # JSON resource listing
+│   │   ├── ConfigureCommand.php                 # Configuration command
+│   │   └── StatusCommand.php                    # Status command
 │   ├── Helpers/
-│   │   └── ConsoleHelper.php        # Pretty console output
-│   ├── JiraApiClient.php            # Jira API integration
-│   ├── ConfigManager.php            # Configuration management
-│   └── Installer.php               # Post-install setup
-├── tests/                           # PHPUnit tests
+│   │   └── ConsoleHelper.php                    # Pretty console output
+│   ├── JiraApiClient.php                        # Jira API integration
+│   ├── ConfigManager.php                        # Configuration management
+│   └── Installer.php                            # Post-install setup
+├── tests/                                       # PHPUnit tests
 ├── .github/
-│   └── workflows/                   # GitHub Actions CI
-├── composer.json                    # Package configuration
-└── README.md                        # This file
+│   └── workflows/                               # GitHub Actions CI
+├── composer.json                                # Package configuration
+└── README.md                                    # This file
 ```
 
 ### Running Tests
@@ -630,6 +729,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **Contributors**: All the amazing people who help improve this tool
 
 ## 📈 Changelog
+
+### [1.1.0] - 2026-06-02
+- 🤖 **NEW**: Non-interactive mode for `create` — pass all fields as flags, get issue key on stdout
+- 🧪 **NEW**: `--dry-run` flag — preview the full JSON payload without creating any ticket
+- 🔍 **NEW**: `list` command — outputs projects, issue-types, priorities, epics, and sprints as JSON
+- 🏃 **NEW**: `--sprint=active` — auto-resolves the current active sprint at runtime
+- 🐛 **FIX**: `getEpics()` migrated from deprecated `/rest/api/3/search` to `/rest/api/3/search/jql`
 
 ### [1.0.0] - 2025-07-03
 - 🎉 Initial release

--- a/bin/jira-wizard
+++ b/bin/jira-wizard
@@ -6,6 +6,7 @@ declare(strict_types=1);
 use MiLopez\JiraCliWizard\Commands\ConfigureCommand;
 use MiLopez\JiraCliWizard\Commands\CreateFromCommand;
 use MiLopez\JiraCliWizard\Commands\CreateTicketCommand;
+use MiLopez\JiraCliWizard\Commands\ListCommand;
 use MiLopez\JiraCliWizard\Commands\StatusCommand;
 use Symfony\Component\Console\Application;
 
@@ -36,6 +37,7 @@ if (empty($argv[1]) || in_array($argv[1], ['--help', '-h', 'help'])) {
 Available commands:
  create       Create a new Jira ticket (default)
  create-from  Create a ticket based on existing one
+ list         List Jira resources as JSON (projects, issue-types, priorities, epics)
  configure    Configure Jira credentials
  status       Show current configuration status
  help         Show help information
@@ -60,6 +62,7 @@ BANNER;
 // Register commands
 $application->add(new CreateTicketCommand());
 $application->add(new CreateFromCommand());
+$application->add(new ListCommand());
 $application->add(new ConfigureCommand());
 $application->add(new StatusCommand());
 

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -10,6 +10,7 @@ use MiLopez\JiraCliWizard\JiraApiClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -33,7 +34,17 @@ class CreateTicketCommand extends Command
         $this
             ->setName('create')
             ->setDescription('Create a new Jira ticket using the interactive wizard')
-            ->setHelp('This command guides you through creating a Jira ticket with smart defaults and suggestions.');
+            ->setHelp('This command guides you through creating a Jira ticket with smart defaults and suggestions.')
+            ->addOption('project', 'p', InputOption::VALUE_REQUIRED, 'Project key (e.g. ALDO)')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'Issue type (e.g. Task, Story, Epic)')
+            ->addOption('summary', 's', InputOption::VALUE_REQUIRED, 'Ticket summary/title')
+            ->addOption('description', 'd', InputOption::VALUE_OPTIONAL, 'Ticket description', '')
+            ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Parent issue or epic key (e.g. ALDO-10)')
+            ->addOption('epic', null, InputOption::VALUE_REQUIRED, 'Epic key to link (alias for --parent)')
+            ->addOption('labels', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated labels (e.g. backend,upgrade)')
+            ->addOption('priority', null, InputOption::VALUE_REQUIRED, 'Priority name (e.g. High, Medium, Low)')
+            ->addOption('sprint', null, InputOption::VALUE_REQUIRED, 'Sprint ID or "active" to use the current active sprint')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show the payload JSON without creating the ticket');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -64,7 +75,14 @@ class CreateTicketCommand extends Command
 
         $this->jiraClient = new JiraApiClient($jiraUrl, $jiraEmail, $jiraToken);
 
-        // Test connection
+        $isDryRun = (bool) $input->getOption('dry-run');
+        $isNonInteractive = $input->getOption('no-interaction') || $this->hasRequiredFlags($input);
+
+        if ($isNonInteractive) {
+            return $this->executeNonInteractive($input, $output, $isDryRun);
+        }
+
+        // Test connection only for interactive mode (non-interactive tests inline)
         $this->consoleHelper->info('🔗 Testing Jira connection...');
         if (!$this->jiraClient->testConnection()) {
             $this->consoleHelper->error('❌ Failed to connect to Jira. Please check your configuration.');
@@ -114,6 +132,122 @@ class CreateTicketCommand extends Command
 
             return Command::FAILURE;
         }
+    }
+
+    private function hasRequiredFlags(InputInterface $input): bool
+    {
+        return $input->getOption('project') !== null
+            && $input->getOption('type') !== null
+            && $input->getOption('summary') !== null;
+    }
+
+    private function executeNonInteractive(InputInterface $input, OutputInterface $output, bool $isDryRun): int
+    {
+        $projectKey = $input->getOption('project');
+        $typeName = $input->getOption('type');
+        $summary = $input->getOption('summary');
+
+        if (!$projectKey || !$typeName || !$summary) {
+            $output->writeln('<error>Non-interactive mode requires --project, --type, and --summary.</error>');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $sprintId = $this->resolveSprintId($input, $projectKey);
+            $payload = $this->buildNonInteractivePayload($input, $projectKey, $typeName, $summary);
+
+            if ($isDryRun) {
+                $dryRunPayload = $payload;
+                if ($sprintId !== null) {
+                    $dryRunPayload['_sprint_id'] = $sprintId;
+                }
+                $output->writeln(json_encode($dryRunPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                return Command::SUCCESS;
+            }
+
+            if (!$this->jiraClient->testConnection()) {
+                $output->writeln('<error>Failed to connect to Jira. Please check your configuration.</error>');
+
+                return Command::FAILURE;
+            }
+
+            $result = $this->jiraClient->createIssue($payload);
+            $issueKey = $result['key'];
+
+            if ($sprintId !== null) {
+                $this->jiraClient->addIssueToSprint($issueKey, $sprintId);
+            }
+
+            $output->write($issueKey);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function resolveSprintId(InputInterface $input, string $projectKey): ?int
+    {
+        $sprint = $input->getOption('sprint');
+
+        if ($sprint === null) {
+            return null;
+        }
+
+        if (strtolower($sprint) === 'active') {
+            $activeSprint = $this->jiraClient->getActiveSprint($projectKey);
+
+            return $activeSprint ? (int) $activeSprint['id'] : null;
+        }
+
+        return (int) $sprint;
+    }
+
+    public function buildNonInteractivePayload(InputInterface $input, string $projectKey, string $typeName, string $summary): array
+    {
+        $description = (string) $input->getOption('description');
+
+        $payload = [
+            'fields' => [
+                'project' => ['key' => strtoupper($projectKey)],
+                'issuetype' => ['name' => $typeName],
+                'summary' => $summary,
+            ],
+        ];
+
+        if ($description !== '') {
+            $payload['fields']['description'] = [
+                'type' => 'doc',
+                'version' => 1,
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [['type' => 'text', 'text' => $description]],
+                    ],
+                ],
+            ];
+        }
+
+        $epicKey = $input->getOption('epic') ?? $input->getOption('parent');
+        if ($epicKey !== null) {
+            $payload['fields']['parent'] = ['key' => strtoupper($epicKey)];
+        }
+
+        $priority = $input->getOption('priority');
+        if ($priority !== null) {
+            $payload['fields']['priority'] = ['name' => $priority];
+        }
+
+        $labelsRaw = $input->getOption('labels');
+        if ($labelsRaw !== null && $labelsRaw !== '') {
+            $payload['fields']['labels'] = array_values(array_filter(array_map('trim', explode(',', $labelsRaw))));
+        }
+
+        return $payload;
     }
 
     private function runWizard(InputInterface $input, OutputInterface $output): ?array

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Commands;
+
+use MiLopez\JiraCliWizard\ConfigManager;
+use MiLopez\JiraCliWizard\JiraApiClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCommand extends Command
+{
+    public const RESOURCES = ['projects', 'issue-types', 'priorities', 'epics', 'sprints'];
+
+    protected static string $defaultName = 'list';
+
+    protected static string $defaultDescription = 'List Jira resources as JSON (for scripting/AI agents)';
+
+    protected function configure(): void
+    {
+        $resourceList = implode(', ', self::RESOURCES);
+
+        $this
+            ->setName('list')
+            ->setDescription('List Jira resources as JSON (for scripting/AI agents)')
+            ->setHelp(
+                "Available resources: {$resourceList}\n\n"
+                . "Examples:\n"
+                . "  jira-wizard list projects\n"
+                . "  jira-wizard list issue-types --project=ALDO\n"
+                . "  jira-wizard list priorities\n"
+                . "  jira-wizard list epics --project=ALDO\n"
+            )
+            ->addArgument(
+                'resource',
+                InputArgument::OPTIONAL,
+                "Resource to list. One of: {$resourceList}"
+            )
+            ->addOption('project', 'p', InputOption::VALUE_REQUIRED, 'Project key (required for issue-types and epics)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $resource = $input->getArgument('resource');
+
+        if (!$resource) {
+            $resourceList = implode(', ', self::RESOURCES);
+            $output->writeln("<info>Available resources:</info> {$resourceList}");
+            $output->writeln('');
+            $output->writeln('Usage: jira-wizard list <resource> [--project=KEY]');
+
+            return Command::SUCCESS;
+        }
+
+        if (!in_array($resource, self::RESOURCES, true)) {
+            $resourceList = implode(', ', self::RESOURCES);
+            $output->writeln("<error>Unknown resource '{$resource}'. Available: {$resourceList}</error>");
+
+            return Command::FAILURE;
+        }
+
+        $config = new ConfigManager();
+
+        if (!$config->isConfigured()) {
+            $output->writeln('<error>Jira CLI is not configured. Please run: jira-wizard configure</error>');
+
+            return Command::FAILURE;
+        }
+
+        $jiraUrl = $config->get('jira_url');
+        $jiraEmail = $config->get('jira_email');
+        $jiraToken = $config->get('jira_token');
+
+        if (!$jiraUrl || !$jiraEmail || !$jiraToken) {
+            $output->writeln('<error>Missing configuration values.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $client = new JiraApiClient($jiraUrl, $jiraEmail, $jiraToken);
+
+        try {
+            $data = $this->fetchResource($client, $resource, $input);
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+
+        $output->write(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        return Command::SUCCESS;
+    }
+
+    private function fetchResource(JiraApiClient $client, string $resource, InputInterface $input): array
+    {
+        switch ($resource) {
+            case 'projects':
+                return array_map(
+                    static fn (array $p) => ['key' => $p['key'], 'name' => $p['name']],
+                    $client->getProjects()
+                );
+
+            case 'issue-types':
+                $projectKey = $input->getOption('project');
+
+                if (!$projectKey) {
+                    throw new \InvalidArgumentException('--project is required for issue-types');
+                }
+
+                return array_values(array_map(
+                    static fn (array $t) => ['id' => $t['id'], 'name' => $t['name'], 'subtask' => $t['subtask']],
+                    array_filter($client->getIssueTypes($projectKey), static fn (array $t) => !$t['subtask'])
+                ));
+
+            case 'priorities':
+                return array_map(
+                    static fn (array $p) => ['id' => $p['id'], 'name' => $p['name']],
+                    $client->getPriorities()
+                );
+
+            case 'epics':
+                $projectKey = $input->getOption('project');
+
+                if (!$projectKey) {
+                    throw new \InvalidArgumentException('--project is required for epics');
+                }
+
+                return array_map(
+                    static fn (array $e) => ['key' => $e['key'], 'summary' => $e['fields']['summary']],
+                    $client->getEpics($projectKey)
+                );
+
+            case 'sprints':
+                $projectKey = $input->getOption('project');
+
+                if (!$projectKey) {
+                    throw new \InvalidArgumentException('--project is required for sprints');
+                }
+
+                $activeSprint = $client->getActiveSprint($projectKey);
+
+                return $activeSprint
+                    ? [['id' => $activeSprint['id'], 'name' => $activeSprint['name'], 'state' => $activeSprint['state']]]
+                    : [];
+
+            default:
+                throw new \InvalidArgumentException("Unknown resource: {$resource}");
+        }
+    }
+}

--- a/src/JiraApiClient.php
+++ b/src/JiraApiClient.php
@@ -127,7 +127,7 @@ class JiraApiClient
         try {
             $jql = "project = {$projectKey} AND type = Epic ORDER BY updated DESC";
 
-            $response = $this->client->get('/rest/api/3/search', [
+            $response = $this->client->get('/rest/api/3/search/jql', [
                 'query' => [
                     'jql' => $jql,
                     'fields' => 'key,summary,status',

--- a/tests/Unit/CreateTicketCommandNonInteractiveTest.php
+++ b/tests/Unit/CreateTicketCommandNonInteractiveTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Tests\Unit;
+
+use MiLopez\JiraCliWizard\Commands\CreateTicketCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CreateTicketCommandNonInteractiveTest extends TestCase
+{
+    private CreateTicketCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new CreateTicketCommand();
+
+        $app = new Application();
+        $app->add($this->command);
+    }
+
+    public function testCommandHasRequiredOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('project'));
+        $this->assertTrue($definition->hasOption('type'));
+        $this->assertTrue($definition->hasOption('summary'));
+        $this->assertTrue($definition->hasOption('description'));
+        $this->assertTrue($definition->hasOption('parent'));
+        $this->assertTrue($definition->hasOption('epic'));
+        $this->assertTrue($definition->hasOption('labels'));
+        $this->assertTrue($definition->hasOption('priority'));
+        $this->assertTrue($definition->hasOption('dry-run'));
+    }
+
+    public function testBuildNonInteractivePayloadMinimal(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Task',
+            '--summary' => 'Test ticket',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Task', 'Test ticket');
+
+        $this->assertSame('ALDO', $payload['fields']['project']['key']);
+        $this->assertSame('Task', $payload['fields']['issuetype']['name']);
+        $this->assertSame('Test ticket', $payload['fields']['summary']);
+        $this->assertArrayNotHasKey('description', $payload['fields']);
+        $this->assertArrayNotHasKey('parent', $payload['fields']);
+        $this->assertArrayNotHasKey('priority', $payload['fields']);
+        $this->assertArrayNotHasKey('labels', $payload['fields']);
+    }
+
+    public function testBuildNonInteractivePayloadProjectKeyIsUppercased(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'aldo',
+            '--type' => 'Task',
+            '--summary' => 'Test ticket',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'aldo', 'Task', 'Test ticket');
+
+        $this->assertSame('ALDO', $payload['fields']['project']['key']);
+    }
+
+    public function testBuildNonInteractivePayloadWithDescription(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Story',
+            '--summary' => 'A story',
+            '--description' => 'Some description',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Story', 'A story');
+
+        $this->assertArrayHasKey('description', $payload['fields']);
+        $this->assertSame('doc', $payload['fields']['description']['type']);
+        $this->assertSame(
+            'Some description',
+            $payload['fields']['description']['content'][0]['content'][0]['text']
+        );
+    }
+
+    public function testBuildNonInteractivePayloadWithParent(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Task',
+            '--summary' => 'Child task',
+            '--parent' => 'aldo-10',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Task', 'Child task');
+
+        $this->assertSame('ALDO-10', $payload['fields']['parent']['key']);
+    }
+
+    public function testBuildNonInteractivePayloadEpicAliasForParent(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Task',
+            '--summary' => 'Child task',
+            '--epic' => 'ALDO-5',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Task', 'Child task');
+
+        $this->assertSame('ALDO-5', $payload['fields']['parent']['key']);
+    }
+
+    public function testBuildNonInteractivePayloadWithPriority(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Task',
+            '--summary' => 'Urgent task',
+            '--priority' => 'High',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Task', 'Urgent task');
+
+        $this->assertSame('High', $payload['fields']['priority']['name']);
+    }
+
+    public function testBuildNonInteractivePayloadWithLabels(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Task',
+            '--summary' => 'Labelled task',
+            '--labels' => 'backend, upgrade, orocommerce',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Task', 'Labelled task');
+
+        $this->assertSame(['backend', 'upgrade', 'orocommerce'], $payload['fields']['labels']);
+    }
+
+    public function testBuildNonInteractivePayloadAllOptions(): void
+    {
+        $input = new ArrayInput([
+            '--project' => 'ALDO',
+            '--type' => 'Story',
+            '--summary' => 'Full story',
+            '--description' => 'Full description',
+            '--epic' => 'ALDO-1',
+            '--priority' => 'Medium',
+            '--labels' => 'upgrade,backend',
+        ], $this->command->getDefinition());
+
+        $payload = $this->command->buildNonInteractivePayload($input, 'ALDO', 'Story', 'Full story');
+
+        $this->assertSame('ALDO', $payload['fields']['project']['key']);
+        $this->assertSame('Story', $payload['fields']['issuetype']['name']);
+        $this->assertSame('Full story', $payload['fields']['summary']);
+        $this->assertSame('doc', $payload['fields']['description']['type']);
+        $this->assertSame('ALDO-1', $payload['fields']['parent']['key']);
+        $this->assertSame('Medium', $payload['fields']['priority']['name']);
+        $this->assertSame(['upgrade', 'backend'], $payload['fields']['labels']);
+    }
+
+    public function testDryRunOutputsJsonWithoutCallingApi(): void
+    {
+        $tester = new CommandTester($this->command);
+
+        $tester->execute([
+            '--project' => 'TEST',
+            '--type' => 'Task',
+            '--summary' => 'Dry run ticket',
+            '--dry-run' => true,
+            '--no-interaction' => true,
+        ]);
+
+        $output = $tester->getDisplay();
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('TEST', $decoded['fields']['project']['key']);
+        $this->assertSame('Task', $decoded['fields']['issuetype']['name']);
+        $this->assertSame('Dry run ticket', $decoded['fields']['summary']);
+    }
+
+    public function testDryRunReturnsSuccessExitCode(): void
+    {
+        $tester = new CommandTester($this->command);
+
+        $tester->execute([
+            '--project' => 'TEST',
+            '--type' => 'Task',
+            '--summary' => 'Dry run ticket',
+            '--dry-run' => true,
+            '--no-interaction' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testNonInteractiveMissingRequiredFlagsReturnsFailure(): void
+    {
+        $tester = new CommandTester($this->command);
+
+        $tester->execute([
+            '--project' => 'TEST',
+            '--no-interaction' => true,
+        ]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+}

--- a/tests/Unit/ListCommandTest.php
+++ b/tests/Unit/ListCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Tests\Unit;
+
+use MiLopez\JiraCliWizard\Commands\ListCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListCommandTest extends TestCase
+{
+    private ListCommand $command;
+
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->command = new ListCommand();
+
+        $app = new Application();
+        $app->add($this->command);
+
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testCommandIsConfiguredProperly(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertSame('list', $this->command->getName());
+        $this->assertTrue($definition->hasArgument('resource'));
+        $this->assertTrue($definition->hasOption('project'));
+    }
+
+    public function testHelpTextMentionsAllResources(): void
+    {
+        $help = $this->command->getHelp();
+
+        foreach (ListCommand::RESOURCES as $resource) {
+            $this->assertStringContainsString($resource, $help);
+        }
+    }
+
+    public function testNoArgumentPrintsAvailableResourcesAndSucceeds(): void
+    {
+        $this->tester->execute([]);
+
+        $output = $this->tester->getDisplay();
+
+        $this->assertSame(0, $this->tester->getStatusCode());
+
+        foreach (ListCommand::RESOURCES as $resource) {
+            $this->assertStringContainsString($resource, $output);
+        }
+    }
+
+    public function testUnknownResourceReturnsFailure(): void
+    {
+        $this->tester->execute(['resource' => 'unknown-resource']);
+
+        $this->assertSame(1, $this->tester->getStatusCode());
+        $this->assertStringContainsString('Unknown resource', $this->tester->getDisplay());
+    }
+
+    public function testUnknownResourceErrorMentionsValidResources(): void
+    {
+        $this->tester->execute(['resource' => 'foo']);
+
+        $output = $this->tester->getDisplay();
+
+        foreach (ListCommand::RESOURCES as $resource) {
+            $this->assertStringContainsString($resource, $output);
+        }
+    }
+
+    public function testAllResourcesAreDeclared(): void
+    {
+        $this->assertSame(['projects', 'issue-types', 'priorities', 'epics', 'sprints'], ListCommand::RESOURCES);
+    }
+}


### PR DESCRIPTION
## Summary

- Add non-interactive mode to `create` — pass all fields as flags (`--project`, `--type`, `--summary`, `--description`, `--epic`/`--parent`, `--labels`, `--priority`, `--sprint`) and get only the issue key on stdout (e.g. `ALDO-123`), making it scriptable and AI-agent friendly
- Add `--dry-run` flag — prints the full JSON payload without hitting the Jira API
- Add `list` command — outputs projects, issue-types, priorities, epics, and sprints as clean JSON for discovery
- Fix `getEpics()` — migrated from deprecated `/rest/api/3/search` to `/rest/api/3/search/jql` (was silently returning `[]`)

## Usage

```bash
# Discover resources
jira-wizard list projects
jira-wizard list issue-types --project=ALDO
jira-wizard list epics --project=ALDO
jira-wizard list sprints --project=ALDO

# Preview payload
jira-wizard create --project=ALDO --type=Task --summary="..." --sprint=active --dry-run

# Create ticket non-interactively (outputs only the key)
KEY=$(jira-wizard create --project=ALDO --type=Task --summary="..." --epic=ALDO-526 --sprint=active --no-interaction)
echo $KEY  # ALDO-123
```

## Test plan

- [x] `--dry-run` outputs valid JSON and exits 0 without creating a ticket
- [x] Non-interactive mode with all flags creates ticket and prints only the key
- [x] `--sprint=active` resolves the current sprint at runtime
- [x] `--epic` and `--parent` both set the parent field correctly
- [x] `list` without argument prints available resources
- [x] `list` with unknown resource exits 1 with error message
- [x] `list epics` now returns results (fixed deprecated API endpoint)
- [x] Interactive wizard unchanged (backward-compatible)
- [x] 31 tests passing, 0 php-cs-fixer issues