### PR TITLE
fork from original

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📈 Changelog
 
+### [Unreleased]
+- **FIX**: Convert simple Markdown-style Description text to Jira ADF in `create` and `create-from`, including `**bold**` text and bullet lists. See `docs/description-formatting.md`.
+
 ### [1.1.0] - 2026-06-02
 - 🤖 **NEW**: Non-interactive mode for `create` — pass all fields as flags, get issue key on stdout
 - 🧪 **NEW**: `--dry-run` flag — preview the full JSON payload without creating any ticket

--- a/bin/jira-wizard
+++ b/bin/jira-wizard
@@ -8,6 +8,7 @@ use MiLopez\JiraCliWizard\Commands\CreateFromCommand;
 use MiLopez\JiraCliWizard\Commands\CreateTicketCommand;
 use MiLopez\JiraCliWizard\Commands\ListCommand;
 use MiLopez\JiraCliWizard\Commands\StatusCommand;
+use MiLopez\JiraCliWizard\Commands\UpdateCommand;
 use Symfony\Component\Console\Application;
 
 // Autoload
@@ -37,6 +38,7 @@ if (empty($argv[1]) || in_array($argv[1], ['--help', '-h', 'help'])) {
 Available commands:
  create       Create a new Jira ticket (default)
  create-from  Create a ticket based on existing one
+ update       Update an existing Jira ticket
  list         List Jira resources as JSON (projects, issue-types, priorities, epics)
  configure    Configure Jira credentials
  status       Show current configuration status
@@ -62,6 +64,7 @@ BANNER;
 // Register commands
 $application->add(new CreateTicketCommand());
 $application->add(new CreateFromCommand());
+$application->add(new UpdateCommand());
 $application->add(new ListCommand());
 $application->add(new ConfigureCommand());
 $application->add(new StatusCommand());

--- a/docs/description-formatting.md
+++ b/docs/description-formatting.md
@@ -1,0 +1,31 @@
+# Description Formatting
+
+`jira-wizard` converts simple Markdown-style descriptions to Jira Atlassian Document Format (ADF) before creating issues.
+
+Supported formatting:
+
+- `**bold text**` becomes Jira bold text.
+- Lines starting with `- ` or `* ` become Jira bullet lists.
+- Blank lines separate paragraphs and list blocks.
+
+Example input:
+
+```md
+**Description**
+Explain the issue.
+
+**Expected result**
+- First validation point.
+- Second validation point with **bold** text.
+```
+
+Expected Jira result:
+
+- Section labels render as bold text.
+- Bullets render as actual Jira bullet lists.
+- Literal `**` markers are not shown in the Jira Description field.
+
+This behavior is used by both:
+
+- `jira-wizard create`
+- `jira-wizard create-from`

--- a/src/Commands/CreateFromCommand.php
+++ b/src/Commands/CreateFromCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MiLopez\JiraCliWizard\Commands;
 
 use MiLopez\JiraCliWizard\ConfigManager;
+use MiLopez\JiraCliWizard\Helpers\AdfHelper;
 use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
 use MiLopez\JiraCliWizard\JiraApiClient;
 use Symfony\Component\Console\Command\Command;
@@ -271,21 +272,7 @@ class CreateFromCommand extends Command
                 'project' => ['key' => $project['key']],
                 'issuetype' => ['id' => $originalFields['issuetype']['id']],
                 'summary' => $summary,
-                'description' => [
-                    'type' => 'doc',
-                    'version' => 1,
-                    'content' => [
-                        [
-                            'type' => 'paragraph',
-                            'content' => [
-                                [
-                                    'type' => 'text',
-                                    'text' => $description,
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+                'description' => AdfHelper::descriptionToDoc($description),
             ],
         ];
 

--- a/src/Commands/CreateFromCommand.php
+++ b/src/Commands/CreateFromCommand.php
@@ -235,6 +235,7 @@ class CreateFromCommand extends Command
         // Get new description
         $question = new Question('📄 Enter description (optional): ', '');
         $description = $this->questionHelper->ask($input, $output, $question) ?? '';
+        $labels = $this->enterLabels($input, $output, $originalFields['labels'] ?? []);
 
         // Ask if user wants to modify copied settings
         $question = new Question('🔧 Do you want to modify the copied settings (assignee, priority, etc.)? (y/N): ', 'n');
@@ -301,13 +302,17 @@ class CreateFromCommand extends Command
             $issueData['fields']['parent'] = ['key' => $epic['key']];
         }
 
+        if (!empty($labels)) {
+            $issueData['fields']['labels'] = $labels;
+        }
+
         // Store sprint ID separately for later processing
         if ($sprint) {
             $issueData['sprint_id'] = $sprint['id'];
         }
 
         // Show summary
-        $this->showNewTicketSummary($output, $project, $originalFields['issuetype'], $summary, $description, $priority, $assignee, $epic, $sprint);
+        $this->showNewTicketSummary($output, $project, $originalFields['issuetype'], $summary, $description, $priority, $assignee, $epic, $sprint, $labels);
 
         // Confirm creation
         $question = new Question('🤔 Create this ticket? (y/N): ', 'n');
@@ -320,7 +325,7 @@ class CreateFromCommand extends Command
         return $issueData;
     }
 
-    private function showNewTicketSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, ?array $epic, ?array $sprint): void
+    private function showNewTicketSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, ?array $epic, ?array $sprint, array $labels): void
     {
         $this->consoleHelper->separator();
         $this->consoleHelper->title('📋 New Ticket Summary');
@@ -349,7 +354,27 @@ class CreateFromCommand extends Command
             $output->writeln("📚 <info>Epic:</info> {$epic['key']}");
         }
 
+        if (!empty($labels)) {
+            $output->writeln('<info>Labels:</info> ' . implode(', ', $labels));
+        }
+
         $this->consoleHelper->separator();
+    }
+
+    private function enterLabels(InputInterface $input, OutputInterface $output, array $currentLabels): array
+    {
+        $default = implode(', ', $currentLabels);
+        $question = new Question('Enter labels (comma-separated, optional): ', $default);
+
+        return $this->parseLabels((string) ($this->questionHelper->ask($input, $output, $question) ?? ''));
+    }
+
+    private function parseLabels(string $labelsRaw): array
+    {
+        $labels = array_map('trim', explode(',', $labelsRaw));
+        $labels = array_filter($labels, static fn (string $label): bool => $label !== '');
+
+        return array_values(array_unique($labels));
     }
 
     // Helper methods (simplified versions)

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MiLopez\JiraCliWizard\Commands;
 
 use MiLopez\JiraCliWizard\ConfigManager;
+use MiLopez\JiraCliWizard\Helpers\AdfHelper;
 use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
 use MiLopez\JiraCliWizard\JiraApiClient;
 use Symfony\Component\Console\Command\Command;
@@ -220,16 +221,7 @@ class CreateTicketCommand extends Command
         ];
 
         if ($description !== '') {
-            $payload['fields']['description'] = [
-                'type' => 'doc',
-                'version' => 1,
-                'content' => [
-                    [
-                        'type' => 'paragraph',
-                        'content' => [['type' => 'text', 'text' => $description]],
-                    ],
-                ],
-            ];
+            $payload['fields']['description'] = AdfHelper::descriptionToDoc($description);
         }
 
         $epicKey = $input->getOption('epic') ?? $input->getOption('parent');
@@ -295,21 +287,7 @@ class CreateTicketCommand extends Command
                 'project' => ['key' => $project['key']],
                 'issuetype' => ['id' => $issueType['id']],
                 'summary' => $summary,
-                'description' => [
-                    'type' => 'doc',
-                    'version' => 1,
-                    'content' => [
-                        [
-                            'type' => 'paragraph',
-                            'content' => [
-                                [
-                                    'type' => 'text',
-                                    'text' => $description,
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+                'description' => AdfHelper::descriptionToDoc($description),
             ],
         ];
 

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -242,9 +242,9 @@ class CreateTicketCommand extends Command
             $payload['fields']['priority'] = ['name' => $priority];
         }
 
-        $labelsRaw = $input->getOption('labels');
-        if ($labelsRaw !== null && $labelsRaw !== '') {
-            $payload['fields']['labels'] = array_values(array_filter(array_map('trim', explode(',', $labelsRaw))));
+        $labels = $this->parseLabels((string) ($input->getOption('labels') ?? ''));
+        if (!empty($labels)) {
+            $payload['fields']['labels'] = $labels;
         }
 
         return $payload;
@@ -324,6 +324,10 @@ class CreateTicketCommand extends Command
 
         if (isset($additionalOptions['epic'])) {
             $issueData['fields']['parent'] = ['key' => $additionalOptions['epic']['key']];
+        }
+
+        if (!empty($additionalOptions['labels'])) {
+            $issueData['fields']['labels'] = $additionalOptions['labels'];
         }
 
         // Store sprint ID separately for later processing
@@ -717,7 +721,23 @@ class CreateTicketCommand extends Command
             $this->consoleHelper->info('No epics found for this project.');
         }
 
+        $this->consoleHelper->info('Labels');
+        $question = new Question('Enter labels (comma-separated, optional): ', '');
+        $labels = $this->parseLabels((string) ($this->questionHelper->ask($input, $output, $question) ?? ''));
+        if (!empty($labels)) {
+            $options['labels'] = $labels;
+            $this->consoleHelper->success('Will add labels: ' . implode(', ', $labels));
+        }
+
         return $options;
+    }
+
+    private function parseLabels(string $labelsRaw): array
+    {
+        $labels = array_map('trim', explode(',', $labelsRaw));
+        $labels = array_filter($labels, static fn (string $label): bool => $label !== '');
+
+        return array_values(array_unique($labels));
     }
 
     private function showSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, array $additionalOptions): void
@@ -747,6 +767,10 @@ class CreateTicketCommand extends Command
 
         if (isset($additionalOptions['epic'])) {
             $output->writeln("📚 <info>Epic:</info> {$additionalOptions['epic']['key']}");
+        }
+
+        if (!empty($additionalOptions['labels'])) {
+            $output->writeln('<info>Labels:</info> ' . implode(', ', $additionalOptions['labels']));
         }
 
         $this->consoleHelper->separator();

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -77,6 +77,15 @@ class CreateTicketCommand extends Command
         $this->jiraClient = new JiraApiClient($jiraUrl, $jiraEmail, $jiraToken);
 
         $isDryRun = (bool) $input->getOption('dry-run');
+
+        // --dry-run must never silently fall through to an interactive path that
+        // could create a ticket. Require the non-interactive flags up front.
+        if ($isDryRun && !$this->hasRequiredFlags($input)) {
+            $this->consoleHelper->error('--dry-run requires --project, --type and --summary.');
+
+            return Command::FAILURE;
+        }
+
         $isNonInteractive = $input->getOption('no-interaction') || $this->hasRequiredFlags($input);
 
         if ($isNonInteractive) {

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Commands;
+
+use MiLopez\JiraCliWizard\ConfigManager;
+use MiLopez\JiraCliWizard\Helpers\AdfHelper;
+use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
+use MiLopez\JiraCliWizard\JiraApiClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateCommand extends Command
+{
+    protected static string $defaultName = 'update';
+
+    protected static string $defaultDescription = 'Update an existing Jira ticket from the command line';
+
+    private JiraApiClient $jiraClient;
+
+    private ConfigManager $config;
+
+    private ConsoleHelper $consoleHelper;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('update')
+            ->setDescription('Update an existing Jira ticket from the command line')
+            ->setHelp('Partially updates an existing ticket. Only the fields you pass are changed.')
+            ->addArgument('key', InputArgument::REQUIRED, 'Issue key to update (e.g. CAM-1755)')
+            ->addOption('summary', 's', InputOption::VALUE_REQUIRED, 'New summary/title')
+            ->addOption('description', 'd', InputOption::VALUE_REQUIRED, 'New description (replaces existing)')
+            ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'Parent issue or epic key (e.g. CAM-1075)')
+            ->addOption('epic', null, InputOption::VALUE_REQUIRED, 'Epic key to link (alias for --parent)')
+            ->addOption('labels', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated labels (replaces existing)')
+            ->addOption('priority', null, InputOption::VALUE_REQUIRED, 'Priority name (e.g. High, Medium, Low)')
+            ->addOption('add-to-sprint', null, InputOption::VALUE_REQUIRED, 'Sprint ID or "active" to add the issue to')
+            ->addOption('comment', null, InputOption::VALUE_REQUIRED, 'Add a comment to the issue')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be sent without applying changes');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->config = new ConfigManager();
+        $this->consoleHelper = new ConsoleHelper($output);
+
+        if (!$this->config->isConfigured()) {
+            $this->consoleHelper->error('Jira CLI is not configured. Please run: jira-wizard configure');
+
+            return Command::FAILURE;
+        }
+
+        $jiraUrl = $this->config->get('jira_url');
+        $jiraEmail = $this->config->get('jira_email');
+        $jiraToken = $this->config->get('jira_token');
+
+        if (!$jiraUrl || !$jiraEmail || !$jiraToken) {
+            $this->consoleHelper->error('❌ Missing configuration values');
+
+            return Command::FAILURE;
+        }
+
+        $this->jiraClient = new JiraApiClient($jiraUrl, $jiraEmail, $jiraToken);
+
+        $issueKey = strtoupper((string) $input->getArgument('key'));
+        $isDryRun = (bool) $input->getOption('dry-run');
+
+        $fields = $this->buildFields($input);
+        $sprintId = $this->resolveSprintId($input, $issueKey, $isDryRun);
+        $comment = $input->getOption('comment');
+
+        if ($fields === [] && $sprintId === null && $comment === null) {
+            $this->consoleHelper->error('Nothing to update. Provide at least one of --summary, --description, --priority, --parent/--epic, --labels, --add-to-sprint or --comment.');
+
+            return Command::FAILURE;
+        }
+
+        if ($isDryRun) {
+            $preview = ['key' => $issueKey, 'fields' => (object) $fields];
+            if ($sprintId !== null) {
+                $preview['_sprint_id'] = $sprintId;
+            }
+            if ($comment !== null) {
+                $preview['_comment'] = (string) $comment;
+            }
+            $output->writeln(json_encode($preview, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            return Command::SUCCESS;
+        }
+
+        if (!$this->jiraClient->testConnection()) {
+            $this->consoleHelper->error('❌ Failed to connect to Jira. Please check your configuration.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            if ($fields !== []) {
+                $this->jiraClient->updateIssue($issueKey, $fields);
+                $this->consoleHelper->success("✅ Updated {$issueKey}");
+            }
+
+            if ($sprintId !== null) {
+                if ($this->jiraClient->addIssueToSprint($issueKey, $sprintId)) {
+                    $this->consoleHelper->success("✅ Added {$issueKey} to sprint {$sprintId}");
+                } else {
+                    $this->consoleHelper->warning('⚠️  Could not add to sprint');
+                }
+            }
+
+            if ($comment !== null) {
+                if ($this->jiraClient->addComment($issueKey, AdfHelper::descriptionToDoc((string) $comment))) {
+                    $this->consoleHelper->success('✅ Comment added');
+                } else {
+                    $this->consoleHelper->warning('⚠️  Could not add comment');
+                }
+            }
+
+            $output->writeln($issueKey);
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->consoleHelper->error('❌ Error: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Build the partial fields payload from the provided options only.
+     */
+    public function buildFields(InputInterface $input): array
+    {
+        $fields = [];
+
+        $summary = $input->getOption('summary');
+        if ($summary !== null) {
+            $fields['summary'] = $summary;
+        }
+
+        $description = $input->getOption('description');
+        if ($description !== null) {
+            $fields['description'] = AdfHelper::descriptionToDoc((string) $description);
+        }
+
+        $epicKey = $input->getOption('epic') ?? $input->getOption('parent');
+        if ($epicKey !== null) {
+            $fields['parent'] = ['key' => strtoupper($epicKey)];
+        }
+
+        $priority = $input->getOption('priority');
+        if ($priority !== null) {
+            $fields['priority'] = ['name' => $priority];
+        }
+
+        $labelsRaw = $input->getOption('labels');
+        if ($labelsRaw !== null) {
+            $fields['labels'] = $this->parseLabels((string) $labelsRaw);
+        }
+
+        return $fields;
+    }
+
+    private function resolveSprintId(InputInterface $input, string $issueKey, bool $isDryRun): ?int
+    {
+        $sprint = $input->getOption('add-to-sprint');
+
+        if ($sprint === null) {
+            return null;
+        }
+
+        if (strtolower($sprint) === 'active') {
+            if ($isDryRun) {
+                return null;
+            }
+            $projectKey = explode('-', $issueKey)[0];
+            $activeSprint = $this->jiraClient->getActiveSprint($projectKey);
+
+            return $activeSprint ? (int) $activeSprint['id'] : null;
+        }
+
+        return (int) $sprint;
+    }
+
+    private function parseLabels(string $labelsRaw): array
+    {
+        $labels = array_map('trim', explode(',', $labelsRaw));
+        $labels = array_filter($labels, static fn (string $label): bool => $label !== '');
+
+        return array_values(array_unique($labels));
+    }
+}

--- a/src/Helpers/AdfHelper.php
+++ b/src/Helpers/AdfHelper.php
@@ -29,6 +29,16 @@ class AdfHelper
                 continue;
             }
 
+            if (preg_match('/^(#{1,6})\s+(.+)$/', $line, $matches) === 1) {
+                self::flushBulletItems($content, $bulletItems);
+                $content[] = [
+                    'type' => 'heading',
+                    'attrs' => ['level' => strlen($matches[1])],
+                    'content' => self::parseInline($matches[2]),
+                ];
+                continue;
+            }
+
             if (preg_match('/^[-*]\s+(.+)$/', $line, $matches) === 1) {
                 $bulletItems[] = [
                     'type' => 'listItem',

--- a/src/Helpers/AdfHelper.php
+++ b/src/Helpers/AdfHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Helpers;
+
+class AdfHelper
+{
+    public static function descriptionToDoc(string $description): array
+    {
+        $description = str_replace(["\r\n", "\r"], "\n", trim($description));
+
+        if ($description === '') {
+            return [
+                'type' => 'doc',
+                'version' => 1,
+                'content' => [],
+            ];
+        }
+
+        $content = [];
+        $bulletItems = [];
+
+        foreach (explode("\n", $description) as $line) {
+            $line = trim($line);
+
+            if ($line === '') {
+                self::flushBulletItems($content, $bulletItems);
+                continue;
+            }
+
+            if (preg_match('/^[-*]\s+(.+)$/', $line, $matches) === 1) {
+                $bulletItems[] = [
+                    'type' => 'listItem',
+                    'content' => [
+                        [
+                            'type' => 'paragraph',
+                            'content' => self::parseInline($matches[1]),
+                        ],
+                    ],
+                ];
+                continue;
+            }
+
+            self::flushBulletItems($content, $bulletItems);
+            $content[] = [
+                'type' => 'paragraph',
+                'content' => self::parseInline($line),
+            ];
+        }
+
+        self::flushBulletItems($content, $bulletItems);
+
+        return [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => $content,
+        ];
+    }
+
+    private static function flushBulletItems(array &$content, array &$bulletItems): void
+    {
+        if ($bulletItems === []) {
+            return;
+        }
+
+        $content[] = [
+            'type' => 'bulletList',
+            'content' => $bulletItems,
+        ];
+        $bulletItems = [];
+    }
+
+    private static function parseInline(string $text): array
+    {
+        $nodes = [];
+        $parts = preg_split('/(\*\*.+?\*\*)/', $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
+        foreach ($parts ?: [] as $part) {
+            if (str_starts_with($part, '**') && str_ends_with($part, '**') && strlen($part) > 4) {
+                $nodes[] = [
+                    'type' => 'text',
+                    'text' => substr($part, 2, -2),
+                    'marks' => [
+                        ['type' => 'strong'],
+                    ],
+                ];
+                continue;
+            }
+
+            $nodes[] = [
+                'type' => 'text',
+                'text' => $part,
+            ];
+        }
+
+        return $nodes !== [] ? $nodes : [['type' => 'text', 'text' => $text]];
+    }
+}

--- a/src/JiraApiClient.php
+++ b/src/JiraApiClient.php
@@ -209,6 +209,39 @@ class JiraApiClient
     }
 
     /**
+     * Update an existing issue (partial update of fields).
+     */
+    public function updateIssue(string $issueKey, array $fields): bool
+    {
+        try {
+            $this->client->put("/rest/api/3/issue/{$issueKey}", [
+                'json' => ['fields' => $fields],
+            ]);
+
+            return true;
+        } catch (RequestException $e) {
+            $errorBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : '';
+            throw new \Exception('Failed to update issue: ' . $e->getMessage() . "\nResponse: " . $errorBody);
+        }
+    }
+
+    /**
+     * Add a comment to an issue. Expects an ADF doc as the comment body.
+     */
+    public function addComment(string $issueKey, array $adfDoc): bool
+    {
+        try {
+            $this->client->post("/rest/api/3/issue/{$issueKey}/comment", [
+                'json' => ['body' => $adfDoc],
+            ]);
+
+            return true;
+        } catch (RequestException $e) {
+            return false;
+        }
+    }
+
+    /**
      * Get issue by key.
      */
     public function getIssue(string $issueKey): ?array

--- a/src/JiraApiClient.php
+++ b/src/JiraApiClient.php
@@ -217,7 +217,7 @@ class JiraApiClient
             $response = $this->client->get("/rest/api/3/issue/{$issueKey}", [
                 'query' => [
                     'expand' => 'names,schema,operations,editmeta,changelog,renderedFields',
-                    'fields' => 'summary,description,issuetype,priority,assignee,project,parent,sprint,status',
+                    'fields' => 'summary,description,issuetype,priority,assignee,project,parent,sprint,status,labels',
                 ],
             ]);
 

--- a/tests/Unit/AdfHelperTest.php
+++ b/tests/Unit/AdfHelperTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Tests\Unit;
+
+use MiLopez\JiraCliWizard\Helpers\AdfHelper;
+use PHPUnit\Framework\TestCase;
+
+class AdfHelperTest extends TestCase
+{
+    public function testEmptyDescriptionProducesEmptyDoc(): void
+    {
+        $doc = AdfHelper::descriptionToDoc('');
+
+        $this->assertSame('doc', $doc['type']);
+        $this->assertSame([], $doc['content']);
+    }
+
+    public function testParagraphIsParsed(): void
+    {
+        $doc = AdfHelper::descriptionToDoc('Just a line');
+
+        $this->assertSame('paragraph', $doc['content'][0]['type']);
+        $this->assertSame('Just a line', $doc['content'][0]['content'][0]['text']);
+    }
+
+    public function testMarkdownHeadingIsParsed(): void
+    {
+        $doc = AdfHelper::descriptionToDoc('## Problem');
+
+        $this->assertSame('heading', $doc['content'][0]['type']);
+        $this->assertSame(2, $doc['content'][0]['attrs']['level']);
+        $this->assertSame('Problem', $doc['content'][0]['content'][0]['text']);
+    }
+
+    public function testHeadingLevelsOneToSix(): void
+    {
+        foreach (range(1, 6) as $level) {
+            $doc = AdfHelper::descriptionToDoc(str_repeat('#', $level) . ' Title');
+            $this->assertSame('heading', $doc['content'][0]['type']);
+            $this->assertSame($level, $doc['content'][0]['attrs']['level']);
+        }
+    }
+
+    public function testSevenHashesIsNotAHeading(): void
+    {
+        $doc = AdfHelper::descriptionToDoc('####### Too deep');
+
+        $this->assertSame('paragraph', $doc['content'][0]['type']);
+        $this->assertSame('####### Too deep', $doc['content'][0]['content'][0]['text']);
+    }
+
+    public function testHeadingFlushesPendingBullets(): void
+    {
+        $doc = AdfHelper::descriptionToDoc("- one\n- two\n## Next");
+
+        $this->assertSame('bulletList', $doc['content'][0]['type']);
+        $this->assertCount(2, $doc['content'][0]['content']);
+        $this->assertSame('heading', $doc['content'][1]['type']);
+    }
+
+    public function testHeadingSupportsInlineBold(): void
+    {
+        $doc = AdfHelper::descriptionToDoc('# A **bold** heading');
+
+        $marks = $doc['content'][0]['content'][1]['marks'] ?? [];
+        $this->assertSame('strong', $marks[0]['type']);
+    }
+
+    public function testMixedDocumentStructure(): void
+    {
+        $doc = AdfHelper::descriptionToDoc("## Heading\nFirst line\n\n- bullet one\n- bullet two\n\nSome **bold** text.");
+
+        $types = array_map(static fn (array $n): string => $n['type'], $doc['content']);
+        $this->assertSame(['heading', 'paragraph', 'bulletList', 'paragraph'], $types);
+    }
+}

--- a/tests/Unit/UpdateCommandTest.php
+++ b/tests/Unit/UpdateCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Tests\Unit;
+
+use MiLopez\JiraCliWizard\Commands\UpdateCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class UpdateCommandTest extends TestCase
+{
+    private UpdateCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new UpdateCommand();
+
+        $app = new Application();
+        $app->add($this->command);
+    }
+
+    public function testCommandHasExpectedOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('key'));
+        $this->assertTrue($definition->hasOption('summary'));
+        $this->assertTrue($definition->hasOption('description'));
+        $this->assertTrue($definition->hasOption('parent'));
+        $this->assertTrue($definition->hasOption('epic'));
+        $this->assertTrue($definition->hasOption('labels'));
+        $this->assertTrue($definition->hasOption('priority'));
+        $this->assertTrue($definition->hasOption('add-to-sprint'));
+        $this->assertTrue($definition->hasOption('comment'));
+        $this->assertTrue($definition->hasOption('dry-run'));
+    }
+
+    public function testBuildFieldsEmptyWhenNoOptions(): void
+    {
+        $input = new ArrayInput(['key' => 'CAM-1'], $this->command->getDefinition());
+
+        $this->assertSame([], $this->command->buildFields($input));
+    }
+
+    public function testBuildFieldsOnlyIncludesProvidedOptions(): void
+    {
+        $input = new ArrayInput([
+            'key' => 'CAM-1755',
+            '--summary' => 'Corrected summary',
+            '--priority' => 'Low',
+        ], $this->command->getDefinition());
+
+        $fields = $this->command->buildFields($input);
+
+        $this->assertSame('Corrected summary', $fields['summary']);
+        $this->assertSame('Low', $fields['priority']['name']);
+        $this->assertArrayNotHasKey('description', $fields);
+        $this->assertArrayNotHasKey('parent', $fields);
+        $this->assertArrayNotHasKey('labels', $fields);
+    }
+
+    public function testBuildFieldsDescriptionBecomesAdfDoc(): void
+    {
+        $input = new ArrayInput([
+            'key' => 'CAM-1',
+            '--description' => '## Heading',
+        ], $this->command->getDefinition());
+
+        $fields = $this->command->buildFields($input);
+
+        $this->assertSame('doc', $fields['description']['type']);
+        $this->assertSame('heading', $fields['description']['content'][0]['type']);
+    }
+
+    public function testBuildFieldsEpicMapsToParentUppercased(): void
+    {
+        $input = new ArrayInput([
+            'key' => 'CAM-1',
+            '--epic' => 'cam-1075',
+        ], $this->command->getDefinition());
+
+        $fields = $this->command->buildFields($input);
+
+        $this->assertSame('CAM-1075', $fields['parent']['key']);
+    }
+
+    public function testBuildFieldsParsesLabels(): void
+    {
+        $input = new ArrayInput([
+            'key' => 'CAM-1',
+            '--labels' => 'backend, upgrade, backend',
+        ], $this->command->getDefinition());
+
+        $fields = $this->command->buildFields($input);
+
+        $this->assertSame(['backend', 'upgrade'], $fields['labels']);
+    }
+}


### PR DESCRIPTION
Changed:

- Interactive create now asks for comma-separated labels, adds them to fields.labels, and shows them in the confirmation summary: jira-cli-wizard/src/Commands/CreateTicketCommand.php:725

  - create-from now prompts for labels, defaults to the source issue’s labels, includes them in the new ticket payload, and shows them in the summary: jira-cli-wizard/src/Commands/CreateFromCommand.php:238

  - Template issue fetch now requests Jira’s labels field: jira-cli-wizard/src/JiraApiClient.php:220

  Verification:

  - php -l passed for all changed PHP files.
  - Full PHPUnit suite passed: 31 tests, 97 assertions.