### PR TITLE
feat: render descriptions as structured ADF

### DIFF
--- a/src/Commands/CreateFromCommand.php
+++ b/src/Commands/CreateFromCommand.php
@@ -6,6 +6,7 @@ namespace MiLopez\JiraCliWizard\Commands;
 
 use MiLopez\JiraCliWizard\ConfigManager;
 use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
+use MiLopez\JiraCliWizard\Helpers\MarkdownToAdf;
 use MiLopez\JiraCliWizard\JiraApiClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -270,21 +271,7 @@ class CreateFromCommand extends Command
                 'project' => ['key' => $project['key']],
                 'issuetype' => ['id' => $originalFields['issuetype']['id']],
                 'summary' => $summary,
-                'description' => [
-                    'type' => 'doc',
-                    'version' => 1,
-                    'content' => [
-                        [
-                            'type' => 'paragraph',
-                            'content' => [
-                                [
-                                    'type' => 'text',
-                                    'text' => $description,
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+                'description' => MarkdownToAdf::convert($description),
             ],
         ];
 

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -6,6 +6,7 @@ namespace MiLopez\JiraCliWizard\Commands;
 
 use MiLopez\JiraCliWizard\ConfigManager;
 use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
+use MiLopez\JiraCliWizard\Helpers\MarkdownToAdf;
 use MiLopez\JiraCliWizard\JiraApiClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -220,16 +221,7 @@ class CreateTicketCommand extends Command
         ];
 
         if ($description !== '') {
-            $payload['fields']['description'] = [
-                'type' => 'doc',
-                'version' => 1,
-                'content' => [
-                    [
-                        'type' => 'paragraph',
-                        'content' => [['type' => 'text', 'text' => $description]],
-                    ],
-                ],
-            ];
+            $payload['fields']['description'] = MarkdownToAdf::convert($description);
         }
 
         $epicKey = $input->getOption('epic') ?? $input->getOption('parent');
@@ -295,21 +287,7 @@ class CreateTicketCommand extends Command
                 'project' => ['key' => $project['key']],
                 'issuetype' => ['id' => $issueType['id']],
                 'summary' => $summary,
-                'description' => [
-                    'type' => 'doc',
-                    'version' => 1,
-                    'content' => [
-                        [
-                            'type' => 'paragraph',
-                            'content' => [
-                                [
-                                    'type' => 'text',
-                                    'text' => $description,
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+                'description' => MarkdownToAdf::convert($description),
             ],
         ];
 

--- a/src/Helpers/MarkdownToAdf.php
+++ b/src/Helpers/MarkdownToAdf.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Helpers;
+
+/**
+ * Converts a plain-text / lightweight Markdown description into an
+ * Atlassian Document Format (ADF) document.
+ *
+ * Jira Cloud's REST API v3 stores rich text as ADF, not as wiki markup.
+ * Passing a raw string wrapped in a single paragraph means blank lines,
+ * headings, lists and bold are rendered literally. This converter turns
+ * the common Markdown constructs into proper ADF nodes so the ticket
+ * reads as intended.
+ *
+ * Supported block syntax:
+ *   - `#` .. `######`  headings (level 1-6)
+ *   - `-`, `*`, `+`    bullet lists
+ *   - `1.`, `1)`       ordered lists
+ *   - blank line       paragraph separator
+ * Supported inline syntax: **bold**, *italic* / _italic_, `code`,
+ * [text](url). Plain text is preserved verbatim, so existing callers
+ * that pass a simple sentence keep working unchanged.
+ */
+final class MarkdownToAdf
+{
+    /**
+     * @return array{type: string, version: int, content: array<int, array<string, mixed>>}
+     */
+    public static function convert(string $text): array
+    {
+        $content = self::blocks($text);
+
+        if ($content === []) {
+            // ADF requires at least one node; keep an empty paragraph.
+            $content = [['type' => 'paragraph', 'content' => []]];
+        }
+
+        return [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function blocks(string $text): array
+    {
+        $lines = preg_split('/\r\n|\r|\n/', $text) ?: [];
+        $content = [];
+        $paragraph = [];
+
+        $count = count($lines);
+        for ($i = 0; $i < $count; ++$i) {
+            $line = $lines[$i];
+
+            if (trim($line) === '') {
+                self::flushParagraph($content, $paragraph);
+                continue;
+            }
+
+            if (preg_match('/^(#{1,6})\s+(.+?)\s*#*$/', $line, $m) === 1) {
+                self::flushParagraph($content, $paragraph);
+                $content[] = [
+                    'type' => 'heading',
+                    'attrs' => ['level' => strlen($m[1])],
+                    'content' => self::inline($m[2]),
+                ];
+                continue;
+            }
+
+            if (preg_match('/^\s*[-*+]\s+(.+)$/', $line) === 1) {
+                self::flushParagraph($content, $paragraph);
+                [$content[], $i] = self::list($lines, $i, $count, 'bullet');
+                continue;
+            }
+
+            if (preg_match('/^\s*\d+[.)]\s+(.+)$/', $line) === 1) {
+                self::flushParagraph($content, $paragraph);
+                [$content[], $i] = self::list($lines, $i, $count, 'ordered');
+                continue;
+            }
+
+            $paragraph[] = $line;
+        }
+
+        self::flushParagraph($content, $paragraph);
+
+        return $content;
+    }
+
+    /**
+     * Appends the collected lines as a paragraph node and resets the buffer.
+     *
+     * @param array<int, array<string, mixed>> $content
+     * @param array<int, string>               $paragraph
+     */
+    private static function flushParagraph(array &$content, array &$paragraph): void
+    {
+        if ($paragraph === []) {
+            return;
+        }
+
+        $nodes = [];
+        foreach ($paragraph as $index => $line) {
+            if ($index > 0) {
+                $nodes[] = ['type' => 'hardBreak'];
+            }
+            foreach (self::inline($line) as $node) {
+                $nodes[] = $node;
+            }
+        }
+
+        $content[] = ['type' => 'paragraph', 'content' => $nodes];
+        $paragraph = [];
+    }
+
+    /**
+     * Consumes consecutive list items starting at $start.
+     *
+     * @param array<int, string> $lines
+     *
+     * @return array{0: array<string, mixed>, 1: int} the list node and the index of the last consumed line
+     */
+    private static function list(array $lines, int $start, int $count, string $kind): array
+    {
+        $pattern = $kind === 'ordered' ? '/^\s*\d+[.)]\s+(.+)$/' : '/^\s*[-*+]\s+(.+)$/';
+        $items = [];
+        $i = $start;
+
+        for (; $i < $count; ++$i) {
+            if (preg_match($pattern, $lines[$i], $m) !== 1) {
+                break;
+            }
+            $items[] = [
+                'type' => 'listItem',
+                'content' => [['type' => 'paragraph', 'content' => self::inline($m[1])]],
+            ];
+        }
+
+        $node = [
+            'type' => $kind === 'ordered' ? 'orderedList' : 'bulletList',
+            'content' => $items,
+        ];
+
+        return [$node, $i - 1];
+    }
+
+    /**
+     * Parses inline marks (bold, italic, code, link) into ADF text nodes.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private static function inline(string $text): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        $patterns = [
+            ['re' => '/`([^`]+)`/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'code']]]],
+            ['re' => '/\*\*([^*]+)\*\*/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'strong']]]],
+            ['re' => '/__([^_]+)__/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'strong']]]],
+            ['re' => '/(?<!\*)\*([^*\s][^*]*)\*(?!\*)/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'em']]]],
+            ['re' => '/_([^_]+)_/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'em']]]],
+            ['re' => '/\[([^\]]+)\]\(([^)]+)\)/', 'mark' => static fn (array $m) => [$m[1], [['type' => 'link', 'attrs' => ['href' => $m[2]]]]]],
+        ];
+
+        $nodes = [];
+        $cursor = 0;
+        $length = strlen($text);
+
+        while ($cursor < $length) {
+            $best = null;
+            $bestPos = $length;
+            $bestMatch = null;
+
+            foreach ($patterns as $pattern) {
+                if (preg_match($pattern['re'], $text, $m, PREG_OFFSET_CAPTURE, $cursor) === 1) {
+                    $pos = $m[0][1];
+                    if ($pos < $bestPos) {
+                        $bestPos = $pos;
+                        $best = $pattern;
+                        $bestMatch = $m;
+                    }
+                }
+            }
+
+            if ($best === null || $bestMatch === null) {
+                $nodes[] = self::textNode(substr($text, $cursor));
+                break;
+            }
+
+            if ($bestPos > $cursor) {
+                $nodes[] = self::textNode(substr($text, $cursor, $bestPos - $cursor));
+            }
+
+            $plainMatch = array_map(static fn ($group) => $group[0], $bestMatch);
+            [$value, $marks] = $best['mark']($plainMatch);
+            $nodes[] = self::textNode($value, $marks);
+
+            $cursor = $bestPos + strlen($bestMatch[0][0]);
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>>|null $marks
+     *
+     * @return array<string, mixed>
+     */
+    private static function textNode(string $text, ?array $marks = null): array
+    {
+        $node = ['type' => 'text', 'text' => $text];
+        if ($marks !== null && $marks !== []) {
+            $node['marks'] = $marks;
+        }
+
+        return $node;
+    }
+}

--- a/tests/Unit/MarkdownToAdfTest.php
+++ b/tests/Unit/MarkdownToAdfTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Tests\Unit;
+
+use MiLopez\JiraCliWizard\Helpers\MarkdownToAdf;
+use PHPUnit\Framework\TestCase;
+
+class MarkdownToAdfTest extends TestCase
+{
+    public function testWrapsRootAsDoc(): void
+    {
+        $doc = MarkdownToAdf::convert('Hello');
+
+        self::assertSame('doc', $doc['type']);
+        self::assertSame(1, $doc['version']);
+        self::assertIsArray($doc['content']);
+    }
+
+    public function testPlainSentenceStaysSingleParagraph(): void
+    {
+        $doc = MarkdownToAdf::convert('Just a simple sentence.');
+
+        self::assertCount(1, $doc['content']);
+        self::assertSame('paragraph', $doc['content'][0]['type']);
+        self::assertSame('Just a simple sentence.', $doc['content'][0]['content'][0]['text']);
+    }
+
+    public function testEmptyStringProducesEmptyParagraph(): void
+    {
+        $doc = MarkdownToAdf::convert('');
+
+        self::assertCount(1, $doc['content']);
+        self::assertSame('paragraph', $doc['content'][0]['type']);
+        self::assertSame([], $doc['content'][0]['content']);
+    }
+
+    public function testBlankLineSplitsParagraphs(): void
+    {
+        $doc = MarkdownToAdf::convert("First paragraph.\n\nSecond paragraph.");
+
+        self::assertCount(2, $doc['content']);
+        self::assertSame('paragraph', $doc['content'][0]['type']);
+        self::assertSame('paragraph', $doc['content'][1]['type']);
+    }
+
+    public function testSingleNewlineBecomesHardBreak(): void
+    {
+        $doc = MarkdownToAdf::convert("Line one\nLine two");
+
+        $nodes = $doc['content'][0]['content'];
+        self::assertSame('text', $nodes[0]['type']);
+        self::assertSame('hardBreak', $nodes[1]['type']);
+        self::assertSame('text', $nodes[2]['type']);
+    }
+
+    public function testHeadings(): void
+    {
+        $doc = MarkdownToAdf::convert("# Title\n\n### Section");
+
+        self::assertSame('heading', $doc['content'][0]['type']);
+        self::assertSame(1, $doc['content'][0]['attrs']['level']);
+        self::assertSame('Title', $doc['content'][0]['content'][0]['text']);
+
+        self::assertSame('heading', $doc['content'][1]['type']);
+        self::assertSame(3, $doc['content'][1]['attrs']['level']);
+    }
+
+    public function testBulletList(): void
+    {
+        $doc = MarkdownToAdf::convert("- one\n- two\n- three");
+
+        self::assertCount(1, $doc['content']);
+        $list = $doc['content'][0];
+        self::assertSame('bulletList', $list['type']);
+        self::assertCount(3, $list['content']);
+        self::assertSame('listItem', $list['content'][0]['type']);
+        self::assertSame('one', $list['content'][0]['content'][0]['content'][0]['text']);
+    }
+
+    public function testOrderedList(): void
+    {
+        $doc = MarkdownToAdf::convert("1. first\n2. second");
+
+        $list = $doc['content'][0];
+        self::assertSame('orderedList', $list['type']);
+        self::assertCount(2, $list['content']);
+    }
+
+    public function testListThenParagraph(): void
+    {
+        $doc = MarkdownToAdf::convert("- item\n\nAfter the list.");
+
+        self::assertSame('bulletList', $doc['content'][0]['type']);
+        self::assertSame('paragraph', $doc['content'][1]['type']);
+        self::assertSame('After the list.', $doc['content'][1]['content'][0]['text']);
+    }
+
+    public function testInlineBold(): void
+    {
+        $doc = MarkdownToAdf::convert('A **bold** word.');
+
+        $nodes = $doc['content'][0]['content'];
+        self::assertSame('A ', $nodes[0]['text']);
+        self::assertSame('bold', $nodes[1]['text']);
+        self::assertSame('strong', $nodes[1]['marks'][0]['type']);
+        self::assertSame(' word.', $nodes[2]['text']);
+    }
+
+    public function testInlineCodeAndLink(): void
+    {
+        $doc = MarkdownToAdf::convert('Run `cmd` then see [docs](https://example.com).');
+
+        $nodes = $doc['content'][0]['content'];
+        self::assertSame('code', $nodes[1]['marks'][0]['type']);
+        self::assertSame('cmd', $nodes[1]['text']);
+
+        $link = $nodes[3];
+        self::assertSame('docs', $link['text']);
+        self::assertSame('link', $link['marks'][0]['type']);
+        self::assertSame('https://example.com', $link['marks'][0]['attrs']['href']);
+    }
+
+    public function testCarriageReturnsAreNormalised(): void
+    {
+        $doc = MarkdownToAdf::convert("First.\r\n\r\nSecond.");
+
+        self::assertCount(2, $doc['content']);
+    }
+}


### PR DESCRIPTION
## What

Descriptions were wrapped in a single ADF paragraph containing the raw
string, so blank lines, headings, lists and bold rendered literally in
Jira Cloud (e.g. `*text*` and `\n` shown verbatim).

This adds a `MarkdownToAdf` converter that turns lightweight Markdown into
proper ADF nodes and uses it in every place that builds a description:
`buildNonInteractivePayload`, the interactive `runWizard`, and
`create-from`.

### Supported syntax
- Headings `#` … `######`
- Bullet lists (`-`, `*`, `+`) and ordered lists (`1.`, `1)`)
- Inline: `**bold**`, `*italic*` / `_italic_`, `` `code` ``, `[text](url)`
- Blank line → paragraph separator; single newline → hard break

Plain text keeps producing a single paragraph, so existing callers are
unaffected.

## Tests
- New `MarkdownToAdfTest` (12 cases). Full suite green: 43 tests / 137
  assertions. php-cs-fixer clean, PHPStan level 6 clean.

## ⚠️ Overlap with #3
Heads-up for the maintainer: #3 also introduces a description→ADF helper
(`AdfHelper`) at the same three call sites, **plus** an interactive
labels feature. The two PRs will conflict on those call sites — they
shouldn't both be merged as-is.

This implementation is richer (headings, ordered lists, italic, inline
code, links, hard breaks) and unit-tested, whereas #3's ADF handles only
bold + bullets and has no tests. #3's genuinely additive part is the
interactive **labels** support, which is orthogonal to the ADF work and
could land on its own. Suggest picking one ADF helper and keeping the
labels feature separate.