### PR TITLE
feat: Add update command and support uploading attachments

### DIFF
--- a/bin/jira-wizard
+++ b/bin/jira-wizard
@@ -8,6 +8,7 @@ use MiLopez\JiraCliWizard\Commands\CreateFromCommand;
 use MiLopez\JiraCliWizard\Commands\CreateTicketCommand;
 use MiLopez\JiraCliWizard\Commands\ListCommand;
 use MiLopez\JiraCliWizard\Commands\StatusCommand;
+use MiLopez\JiraCliWizard\Commands\UpdateCommand;
 use Symfony\Component\Console\Application;
 
 // Autoload
@@ -37,6 +38,7 @@ if (empty($argv[1]) || in_array($argv[1], ['--help', '-h', 'help'])) {
 Available commands:
  create       Create a new Jira ticket (default)
  create-from  Create a ticket based on existing one
+ update       Update an existing Jira ticket
  list         List Jira resources as JSON (projects, issue-types, priorities, epics)
  configure    Configure Jira credentials
  status       Show current configuration status
@@ -62,6 +64,7 @@ BANNER;
 // Register commands
 $application->add(new CreateTicketCommand());
 $application->add(new CreateFromCommand());
+$application->add(new UpdateCommand());
 $application->add(new ListCommand());
 $application->add(new ConfigureCommand());
 $application->add(new StatusCommand());

--- a/src/Commands/CreateFromCommand.php
+++ b/src/Commands/CreateFromCommand.php
@@ -45,6 +45,12 @@ class CreateFromCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Override the project (use different project than original)'
             )
+            ->addOption(
+                'attachment',
+                'a',
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+                'Path to attachment files/images to upload'
+            )
             ->setHelp(
                 'This command creates a new ticket using an existing ticket as a template.' . PHP_EOL .
                 'It will copy the issue type, priority, assignee, epic, and sprint from the original ticket.' . PHP_EOL .
@@ -123,6 +129,12 @@ class CreateFromCommand extends Command
                 return Command::SUCCESS;
             }
 
+            $attachments = $input->getOption('attachment') ?? [];
+            if (isset($ticketData['_attachments'])) {
+                $attachments = array_merge($attachments, $ticketData['_attachments']);
+                unset($ticketData['_attachments']);
+            }
+
             // Create the ticket
             $this->consoleHelper->info('🚀 Creating ticket...');
             $result = $this->jiraClient->createIssue($ticketData);
@@ -141,6 +153,20 @@ class CreateFromCommand extends Command
                     $this->consoleHelper->success('✅ Added to sprint!');
                 } else {
                     $this->consoleHelper->warning('⚠️  Could not add to sprint (ticket created successfully)');
+                }
+            }
+
+            // Upload attachments if any
+            if (!empty($attachments)) {
+                $this->consoleHelper->info('📎 Uploading attachments...');
+                foreach ($attachments as $filePath) {
+                    try {
+                        $this->consoleHelper->info("  Uploading " . basename($filePath) . "...");
+                        $this->jiraClient->uploadAttachment($newIssueKey, $filePath);
+                        $this->consoleHelper->success("  ✅ Uploaded: " . basename($filePath));
+                    } catch (\Exception $e) {
+                        $this->consoleHelper->warning("  ⚠️  Failed to upload " . basename($filePath) . ": " . $e->getMessage());
+                    }
                 }
             }
 
@@ -306,8 +332,36 @@ class CreateFromCommand extends Command
             $issueData['sprint_id'] = $sprint['id'];
         }
 
+        // Ask for attachments
+        $attachments = [];
+        if (!$input->getOption('no-interaction')) {
+            $this->consoleHelper->separator();
+            $this->consoleHelper->info('📎 Attachment Options');
+            while (true) {
+                $question = new Question('Enter path to attachment file (or press enter to skip/finish): ', '');
+                $filePath = $this->questionHelper->ask($input, $output, $question);
+
+                if ($filePath === null || trim($filePath) === '') {
+                    break;
+                }
+
+                $filePath = trim($filePath);
+                if (!file_exists($filePath)) {
+                    $this->consoleHelper->warning("❌ File not found at '{$filePath}'. Please enter a valid path.");
+                    continue;
+                }
+
+                $attachments[] = $filePath;
+                $this->consoleHelper->success("✅ Added attachment: " . basename($filePath));
+            }
+        }
+
+        if (!empty($attachments)) {
+            $issueData['_attachments'] = $attachments;
+        }
+
         // Show summary
-        $this->showNewTicketSummary($output, $project, $originalFields['issuetype'], $summary, $description, $priority, $assignee, $epic, $sprint);
+        $this->showNewTicketSummary($output, $project, $originalFields['issuetype'], $summary, $description, $priority, $assignee, $epic, $sprint, $attachments);
 
         // Confirm creation
         $question = new Question('🤔 Create this ticket? (y/N): ', 'n');
@@ -320,7 +374,7 @@ class CreateFromCommand extends Command
         return $issueData;
     }
 
-    private function showNewTicketSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, ?array $epic, ?array $sprint): void
+    private function showNewTicketSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, ?array $epic, ?array $sprint, array $attachments = []): void
     {
         $this->consoleHelper->separator();
         $this->consoleHelper->title('📋 New Ticket Summary');
@@ -347,6 +401,13 @@ class CreateFromCommand extends Command
 
         if ($epic) {
             $output->writeln("📚 <info>Epic:</info> {$epic['key']}");
+        }
+
+        if (!empty($attachments)) {
+            $output->writeln("📎 <info>Attachments:</info>");
+            foreach ($attachments as $filePath) {
+                $output->writeln("  - " . basename($filePath));
+            }
         }
 
         $this->consoleHelper->separator();

--- a/src/Commands/CreateTicketCommand.php
+++ b/src/Commands/CreateTicketCommand.php
@@ -44,6 +44,7 @@ class CreateTicketCommand extends Command
             ->addOption('labels', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated labels (e.g. backend,upgrade)')
             ->addOption('priority', null, InputOption::VALUE_REQUIRED, 'Priority name (e.g. High, Medium, Low)')
             ->addOption('sprint', null, InputOption::VALUE_REQUIRED, 'Sprint ID or "active" to use the current active sprint')
+            ->addOption('attachment', 'a', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Path to attachment files/images to upload')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show the payload JSON without creating the ticket');
     }
 
@@ -97,12 +98,19 @@ class CreateTicketCommand extends Command
             // Start the wizard
             $this->consoleHelper->title('🎯 Jira Ticket Creation Wizard');
 
+            $attachments = $input->getOption('attachment') ?? [];
             $ticketData = $this->runWizard($input, $output);
 
             if (!$ticketData) {
                 $this->consoleHelper->warning('Ticket creation cancelled.');
 
                 return Command::SUCCESS;
+            }
+
+            // Merge wizard attachments if any
+            if (isset($ticketData['_attachments'])) {
+                $attachments = array_merge($attachments, $ticketData['_attachments']);
+                unset($ticketData['_attachments']);
             }
 
             // Create the ticket
@@ -123,6 +131,20 @@ class CreateTicketCommand extends Command
                     $this->consoleHelper->success('✅ Added to sprint!');
                 } else {
                     $this->consoleHelper->warning('⚠️  Could not add to sprint (ticket created successfully)');
+                }
+            }
+
+            // Upload attachments if any
+            if (!empty($attachments)) {
+                $this->consoleHelper->info('📎 Uploading attachments...');
+                foreach ($attachments as $filePath) {
+                    try {
+                        $this->consoleHelper->info("  Uploading " . basename($filePath) . "...");
+                        $this->jiraClient->uploadAttachment($issueKey, $filePath);
+                        $this->consoleHelper->success("  ✅ Uploaded: " . basename($filePath));
+                    } catch (\Exception $e) {
+                        $this->consoleHelper->warning("  ⚠️  Failed to upload " . basename($filePath) . ": " . $e->getMessage());
+                    }
                 }
             }
 
@@ -154,6 +176,15 @@ class CreateTicketCommand extends Command
         }
 
         try {
+            $attachments = $input->getOption('attachment') ?? [];
+            foreach ($attachments as $filePath) {
+                if (!file_exists($filePath)) {
+                    $output->writeln("<error>Attachment file not found: {$filePath}</error>");
+
+                    return Command::FAILURE;
+                }
+            }
+
             $sprintId = $this->resolveSprintId($input, $projectKey);
             $payload = $this->buildNonInteractivePayload($input, $projectKey, $typeName, $summary);
 
@@ -161,6 +192,9 @@ class CreateTicketCommand extends Command
                 $dryRunPayload = $payload;
                 if ($sprintId !== null) {
                     $dryRunPayload['_sprint_id'] = $sprintId;
+                }
+                if (!empty($attachments)) {
+                    $dryRunPayload['_attachments'] = $attachments;
                 }
                 $output->writeln(json_encode($dryRunPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 
@@ -178,6 +212,10 @@ class CreateTicketCommand extends Command
 
             if ($sprintId !== null) {
                 $this->jiraClient->addIssueToSprint($issueKey, $sprintId);
+            }
+
+            foreach ($attachments as $filePath) {
+                $this->jiraClient->uploadAttachment($issueKey, $filePath);
             }
 
             $output->write($issueKey);
@@ -253,41 +291,45 @@ class CreateTicketCommand extends Command
     private function runWizard(InputInterface $input, OutputInterface $output): ?array
     {
         // Step 1: Select Project
-        $this->consoleHelper->step('1/7', 'Select Project');
+        $this->consoleHelper->step('1/8', 'Select Project');
         $project = $this->selectProject($input, $output);
         if (!$project) {
             return null;
         }
 
         // Step 2: Select Issue Type
-        $this->consoleHelper->step('2/7', 'Select Issue Type');
+        $this->consoleHelper->step('2/8', 'Select Issue Type');
         $issueType = $this->selectIssueType($input, $output, $project['key']);
         if (!$issueType) {
             return null;
         }
 
         // Step 3: Enter Summary
-        $this->consoleHelper->step('3/7', 'Enter Summary');
+        $this->consoleHelper->step('3/8', 'Enter Summary');
         $summary = $this->enterSummary($input, $output);
         if (!$summary) {
             return null;
         }
 
         // Step 4: Enter Description
-        $this->consoleHelper->step('4/7', 'Enter Description');
+        $this->consoleHelper->step('4/8', 'Enter Description');
         $description = $this->enterDescription($input, $output);
 
         // Step 5: Select Priority
-        $this->consoleHelper->step('5/7', 'Select Priority');
+        $this->consoleHelper->step('5/8', 'Select Priority');
         $priority = $this->selectPriority($input, $output);
 
         // Step 6: Select Assignee
-        $this->consoleHelper->step('6/7', 'Select Assignee');
+        $this->consoleHelper->step('6/8', 'Select Assignee');
         $assignee = $this->selectAssignee($input, $output, $project['key']);
 
         // Step 7: Additional Options
-        $this->consoleHelper->step('7/7', 'Additional Options');
+        $this->consoleHelper->step('7/8', 'Additional Options');
         $additionalOptions = $this->selectAdditionalOptions($input, $output, $project['key']);
+
+        // Step 8: Add Attachments
+        $this->consoleHelper->step('8/8', 'Add Attachments');
+        $attachments = $this->enterAttachments($input, $output);
 
         // Build issue data
         $issueData = [
@@ -331,8 +373,13 @@ class CreateTicketCommand extends Command
             $issueData['sprint_id'] = $additionalOptions['sprint']['id'];
         }
 
+        // Store attachments separately for later processing
+        if (!empty($attachments)) {
+            $issueData['_attachments'] = $attachments;
+        }
+
         // Show summary
-        $this->showSummary($output, $project, $issueType, $summary, $description, $priority, $assignee, $additionalOptions);
+        $this->showSummary($output, $project, $issueType, $summary, $description, $priority, $assignee, $additionalOptions, $attachments);
 
         // Confirm creation
         $confirmQuestion = new Question('🤔 Create this ticket? (Y/n): ', 'y');
@@ -720,7 +767,7 @@ class CreateTicketCommand extends Command
         return $options;
     }
 
-    private function showSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, array $additionalOptions): void
+    private function showSummary(OutputInterface $output, array $project, array $issueType, string $summary, string $description, ?array $priority, ?array $assignee, array $additionalOptions, array $attachments = []): void
     {
         $this->consoleHelper->separator();
         $this->consoleHelper->title('📋 Ticket Summary');
@@ -749,6 +796,39 @@ class CreateTicketCommand extends Command
             $output->writeln("📚 <info>Epic:</info> {$additionalOptions['epic']['key']}");
         }
 
+        if (!empty($attachments)) {
+            $output->writeln("📎 <info>Attachments:</info>");
+            foreach ($attachments as $filePath) {
+                $output->writeln("  - " . basename($filePath));
+            }
+        }
+
         $this->consoleHelper->separator();
+    }
+
+    private function enterAttachments(InputInterface $input, OutputInterface $output): array
+    {
+        $attachments = [];
+        $this->consoleHelper->info('📎 You can upload multiple files or images to the ticket.');
+
+        while (true) {
+            $question = new Question('Enter path to attachment file (or press enter to skip/finish): ', '');
+            $filePath = $this->questionHelper->ask($input, $output, $question);
+
+            if ($filePath === null || trim($filePath) === '') {
+                break;
+            }
+
+            $filePath = trim($filePath);
+            if (!file_exists($filePath)) {
+                $this->consoleHelper->warning("❌ File not found at '{$filePath}'. Please enter a valid path.");
+                continue;
+            }
+
+            $attachments[] = $filePath;
+            $this->consoleHelper->success("✅ Added attachment: " . basename($filePath));
+        }
+
+        return $attachments;
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -46,6 +46,7 @@ class UpdateCommand extends Command
             ->addOption('assignee', null, InputOption::VALUE_REQUIRED, 'New assignee (displayName, email, accountId, or "unassigned")')
             ->addOption('labels', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated labels')
             ->addOption('sprint', null, InputOption::VALUE_REQUIRED, 'Sprint ID or "active"')
+            ->addOption('attachment', 'a', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Path to attachment files/images to upload')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show the payload JSON without updating the ticket');
     }
 
@@ -96,14 +97,26 @@ class UpdateCommand extends Command
         $isNonInteractive = $input->getOption('no-interaction') || $this->hasUpdateOptions($input);
 
         try {
+            $attachments = $input->getOption('attachment') ?? [];
             if ($isNonInteractive) {
                 $payload = $this->buildNonInteractivePayload($input, $projectKey);
+                foreach ($attachments as $filePath) {
+                    if (!file_exists($filePath)) {
+                        $this->consoleHelper->error("❌ Attachment file not found: {$filePath}");
+
+                        return Command::FAILURE;
+                    }
+                }
             } else {
                 $payload = $this->runInteractiveWizard($input, $output, $issue, $projectKey);
+                if (isset($payload['_attachments'])) {
+                    $attachments = array_merge($attachments, $payload['_attachments']);
+                    unset($payload['_attachments']);
+                }
             }
 
-            if (empty($payload['fields']) && empty($payload['sprint_id'])) {
-                $this->consoleHelper->warning('No fields to update.');
+            if (empty($payload['fields']) && empty($payload['sprint_id']) && empty($attachments)) {
+                $this->consoleHelper->warning('No fields or attachments to update.');
 
                 return Command::SUCCESS;
             }
@@ -117,6 +130,9 @@ class UpdateCommand extends Command
                 $dryRunPayload = $payload;
                 if ($sprintId) {
                     $dryRunPayload['_sprint_id'] = $sprintId;
+                }
+                if (!empty($attachments)) {
+                    $dryRunPayload['_attachments'] = $attachments;
                 }
                 $output->writeln(json_encode($dryRunPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 
@@ -135,6 +151,20 @@ class UpdateCommand extends Command
                     $this->consoleHelper->success('✅ Added to sprint successfully!');
                 } else {
                     $this->consoleHelper->warning('⚠️ Could not add to sprint.');
+                }
+            }
+
+            // Upload attachments if any
+            if (!empty($attachments)) {
+                $this->consoleHelper->info('📎 Uploading attachments...');
+                foreach ($attachments as $filePath) {
+                    try {
+                        $this->consoleHelper->info("  Uploading " . basename($filePath) . "...");
+                        $this->jiraClient->uploadAttachment($issueKey, $filePath);
+                        $this->consoleHelper->success("  ✅ Uploaded: " . basename($filePath));
+                    } catch (\Exception $e) {
+                        $this->consoleHelper->warning("  ⚠️  Failed to upload " . basename($filePath) . ": " . $e->getMessage());
+                    }
                 }
             }
 
@@ -399,6 +429,32 @@ class UpdateCommand extends Command
             if (strtolower($addToSprint) === 'y') {
                 $payload['sprint_id'] = (int) $sprint['id'];
             }
+        }
+
+        // 9. Attachments
+        $attachments = [];
+        $this->consoleHelper->separator();
+        $this->consoleHelper->info('📎 Attachment Options');
+        while (true) {
+            $question = new Question('Enter path to attachment file (or press enter to skip/finish): ', '');
+            $filePath = $this->questionHelper->ask($input, $output, $question);
+
+            if ($filePath === null || trim($filePath) === '') {
+                break;
+            }
+
+            $filePath = trim($filePath);
+            if (!file_exists($filePath)) {
+                $this->consoleHelper->warning("❌ File not found at '{$filePath}'. Please enter a valid path.");
+                continue;
+            }
+
+            $attachments[] = $filePath;
+            $this->consoleHelper->success("✅ Added attachment: " . basename($filePath));
+        }
+
+        if (!empty($attachments)) {
+            $payload['_attachments'] = $attachments;
         }
 
         return $payload;

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiLopez\JiraCliWizard\Commands;
+
+use MiLopez\JiraCliWizard\ConfigManager;
+use MiLopez\JiraCliWizard\Helpers\ConsoleHelper;
+use MiLopez\JiraCliWizard\JiraApiClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+
+class UpdateCommand extends Command
+{
+    protected static string $defaultName = 'update';
+
+    protected static string $defaultDescription = 'Update an existing Jira ticket';
+
+    private JiraApiClient $jiraClient;
+
+    private ConfigManager $config;
+
+    private QuestionHelper $questionHelper;
+
+    private ConsoleHelper $consoleHelper;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('update')
+            ->setDescription('Update an existing Jira ticket')
+            ->setHelp('This command allows you to update fields of an existing Jira ticket.')
+            ->addArgument('issue-key', InputArgument::REQUIRED, 'The issue key to update (e.g. CAMPUS-395)')
+            ->addOption('summary', 's', InputOption::VALUE_REQUIRED, 'New ticket summary/title')
+            ->addOption('description', 'd', InputOption::VALUE_REQUIRED, 'New ticket description')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'New issue type (e.g. Task, Story, Bug)')
+            ->addOption('epic', null, InputOption::VALUE_REQUIRED, 'New epic or parent key')
+            ->addOption('parent', null, InputOption::VALUE_REQUIRED, 'New parent key (alias for --epic)')
+            ->addOption('priority', null, InputOption::VALUE_REQUIRED, 'New priority name (e.g. High, Medium, Low)')
+            ->addOption('assignee', null, InputOption::VALUE_REQUIRED, 'New assignee (displayName, email, accountId, or "unassigned")')
+            ->addOption('labels', 'l', InputOption::VALUE_REQUIRED, 'Comma-separated labels')
+            ->addOption('sprint', null, InputOption::VALUE_REQUIRED, 'Sprint ID or "active"')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show the payload JSON without updating the ticket');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->config = new ConfigManager();
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $this->questionHelper = $helper;
+        $this->consoleHelper = new ConsoleHelper($output);
+
+        if (!$this->config->isConfigured()) {
+            $this->consoleHelper->error('Jira CLI is not configured. Please run: jira-wizard configure');
+
+            return Command::FAILURE;
+        }
+
+        $jiraUrl = $this->config->get('jira_url');
+        $jiraEmail = $this->config->get('jira_email');
+        $jiraToken = $this->config->get('jira_token');
+
+        if (!$jiraUrl || !$jiraEmail || !$jiraToken) {
+            $this->consoleHelper->error('❌ Missing configuration values');
+
+            return Command::FAILURE;
+        }
+
+        $this->jiraClient = new JiraApiClient($jiraUrl, $jiraEmail, $jiraToken);
+
+        $issueKey = strtoupper($input->getArgument('issue-key'));
+
+        $this->consoleHelper->info("🔗 Fetching issue {$issueKey}...");
+        $issue = $this->jiraClient->getIssue($issueKey);
+
+        if (!$issue) {
+            $this->consoleHelper->error("❌ Issue {$issueKey} not found or inaccessible.");
+
+            return Command::FAILURE;
+        }
+
+        $projectKey = $issue['fields']['project']['key'] ?? '';
+        if (!$projectKey) {
+            $parts = explode('-', $issueKey);
+            $projectKey = $parts[0] ?? '';
+        }
+
+        $isDryRun = (bool) $input->getOption('dry-run');
+        $isNonInteractive = $input->getOption('no-interaction') || $this->hasUpdateOptions($input);
+
+        try {
+            if ($isNonInteractive) {
+                $payload = $this->buildNonInteractivePayload($input, $projectKey);
+            } else {
+                $payload = $this->runInteractiveWizard($input, $output, $issue, $projectKey);
+            }
+
+            if (empty($payload['fields']) && empty($payload['sprint_id'])) {
+                $this->consoleHelper->warning('No fields to update.');
+
+                return Command::SUCCESS;
+            }
+
+            // Extract sprint ID if set
+            $sprintId = $payload['sprint_id'] ?? null;
+            unset($payload['sprint_id']);
+
+            if ($isDryRun) {
+                $this->consoleHelper->info('📋 Dry Run Payload:');
+                $dryRunPayload = $payload;
+                if ($sprintId) {
+                    $dryRunPayload['_sprint_id'] = $sprintId;
+                }
+                $output->writeln(json_encode($dryRunPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+                return Command::SUCCESS;
+            }
+
+            if (!empty($payload['fields'])) {
+                $this->consoleHelper->info("🚀 Updating issue {$issueKey}...");
+                $this->jiraClient->updateIssue($issueKey, $payload);
+                $this->consoleHelper->success('✅ Issue updated successfully!');
+            }
+
+            if ($sprintId) {
+                $this->consoleHelper->info("🏃 Adding issue to sprint ID {$sprintId}...");
+                if ($this->jiraClient->addIssueToSprint($issueKey, $sprintId)) {
+                    $this->consoleHelper->success('✅ Added to sprint successfully!');
+                } else {
+                    $this->consoleHelper->warning('⚠️ Could not add to sprint.');
+                }
+            }
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->consoleHelper->error('❌ Error: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function hasUpdateOptions(InputInterface $input): bool
+    {
+        return $input->getOption('summary') !== null
+            || $input->getOption('description') !== null
+            || $input->getOption('type') !== null
+            || $input->getOption('epic') !== null
+            || $input->getOption('parent') !== null
+            || $input->getOption('priority') !== null
+            || $input->getOption('assignee') !== null
+            || $input->getOption('labels') !== null
+            || $input->getOption('sprint') !== null;
+    }
+
+    private function buildNonInteractivePayload(InputInterface $input, string $projectKey): array
+    {
+        $payload = ['fields' => []];
+
+        $summary = $input->getOption('summary');
+        if ($summary !== null) {
+            $payload['fields']['summary'] = $summary;
+        }
+
+        $description = $input->getOption('description');
+        if ($description !== null) {
+            $payload['fields']['description'] = [
+                'type' => 'doc',
+                'version' => 1,
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [['type' => 'text', 'text' => $description]],
+                    ],
+                ],
+            ];
+        }
+
+        $type = $input->getOption('type');
+        if ($type !== null) {
+            $payload['fields']['issuetype'] = ['name' => $type];
+        }
+
+        $epicKey = $input->getOption('epic') ?? $input->getOption('parent');
+        if ($epicKey !== null) {
+            if (strtolower($epicKey) === 'none' || strtolower($epicKey) === 'null') {
+                $payload['fields']['parent'] = null;
+            } else {
+                $payload['fields']['parent'] = ['key' => strtoupper($epicKey)];
+            }
+        }
+
+        $priority = $input->getOption('priority');
+        if ($priority !== null) {
+            $payload['fields']['priority'] = ['name' => $priority];
+        }
+
+        $assignee = $input->getOption('assignee');
+        if ($assignee !== null) {
+            if (strtolower($assignee) === 'unassigned' || strtolower($assignee) === 'none') {
+                $payload['fields']['assignee'] = null;
+            } else {
+                $accountId = $this->resolveAssigneeAccountId($assignee, $projectKey);
+                $payload['fields']['assignee'] = ['accountId' => $accountId];
+            }
+        }
+
+        $labelsRaw = $input->getOption('labels');
+        if ($labelsRaw !== null) {
+            $payload['fields']['labels'] = array_values(array_filter(array_map('trim', explode(',', $labelsRaw))));
+        }
+
+        $sprint = $input->getOption('sprint');
+        if ($sprint !== null) {
+            if (strtolower($sprint) === 'active') {
+                $activeSprint = $this->jiraClient->getActiveSprint($projectKey);
+                if ($activeSprint) {
+                    $payload['sprint_id'] = (int) $activeSprint['id'];
+                }
+            } elseif (is_numeric($sprint)) {
+                $payload['sprint_id'] = (int) $sprint;
+            }
+        }
+
+        return $payload;
+    }
+
+    private function resolveAssigneeAccountId(string $assigneeInput, string $projectKey): string
+    {
+        $users = $this->jiraClient->getAssignableUsers($projectKey);
+        foreach ($users as $user) {
+            if ($user['accountId'] === $assigneeInput) {
+                return $user['accountId'];
+            }
+            if (isset($user['displayName']) && strtolower($user['displayName']) === strtolower($assigneeInput)) {
+                return $user['accountId'];
+            }
+            if (isset($user['emailAddress']) && strtolower($user['emailAddress']) === strtolower($assigneeInput)) {
+                return $user['accountId'];
+            }
+        }
+
+        // Try partial matching
+        foreach ($users as $user) {
+            if (isset($user['displayName']) && stripos($user['displayName'], $assigneeInput) !== false) {
+                return $user['accountId'];
+            }
+        }
+
+        throw new \Exception("Could not find assignable user matching '{$assigneeInput}'");
+    }
+
+    private function runInteractiveWizard(InputInterface $input, OutputInterface $output, array $issue, string $projectKey): array
+    {
+        $payload = ['fields' => []];
+
+        $currentSummary = $issue['fields']['summary'] ?? '';
+        $currentDesc = '';
+        if (isset($issue['fields']['description']['content'][0]['content'][0]['text'])) {
+            $currentDesc = $issue['fields']['description']['content'][0]['content'][0]['text'];
+        }
+
+        $this->consoleHelper->title('🔧 Jira Ticket Update Wizard');
+
+        // 1. Summary
+        $question = new Question("Summary [{$currentSummary}]: ", $currentSummary);
+        $summary = $this->questionHelper->ask($input, $output, $question);
+        if ($summary !== $currentSummary) {
+            $payload['fields']['summary'] = $summary;
+        }
+
+        // 2. Description
+        $question = new Question("Description [{$currentDesc}]: ", $currentDesc);
+        $description = $this->questionHelper->ask($input, $output, $question);
+        if ($description !== $currentDesc) {
+            $payload['fields']['description'] = [
+                'type' => 'doc',
+                'version' => 1,
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [['type' => 'text', 'text' => $description]],
+                    ],
+                ],
+            ];
+        }
+
+        // 3. Issue Type
+        $issueTypes = $this->jiraClient->getIssueTypes($projectKey);
+        $currentTypeName = $issue['fields']['issuetype']['name'] ?? '';
+        if (!empty($issueTypes)) {
+            $typeChoices = [];
+            $defaultIndex = 0;
+            foreach ($issueTypes as $index => $type) {
+                $typeChoices[$index] = $type['name'];
+                if (strtolower($type['name']) === strtolower($currentTypeName)) {
+                    $defaultIndex = $index;
+                }
+            }
+
+            $question = new ChoiceQuestion("Select Issue Type [{$currentTypeName}]: ", $typeChoices, $defaultIndex);
+            $selectedType = $this->questionHelper->ask($input, $output, $question);
+            if ($selectedType !== $currentTypeName) {
+                $payload['fields']['issuetype'] = ['name' => $selectedType];
+            }
+        }
+
+        // 4. Priority
+        $priorities = $this->jiraClient->getPriorities();
+        $currentPriorityName = $issue['fields']['priority']['name'] ?? '';
+        if (!empty($priorities)) {
+            $priorityChoices = [];
+            $defaultIndex = 0;
+            foreach ($priorities as $index => $pri) {
+                $priorityChoices[$index] = $pri['name'];
+                if (strtolower($pri['name']) === strtolower($currentPriorityName)) {
+                    $defaultIndex = $index;
+                }
+            }
+
+            $question = new ChoiceQuestion("Select Priority [{$currentPriorityName}]: ", $priorityChoices, $defaultIndex);
+            $selectedPriority = $this->questionHelper->ask($input, $output, $question);
+            if ($selectedPriority !== $currentPriorityName) {
+                $payload['fields']['priority'] = ['name' => $selectedPriority];
+            }
+        }
+
+        // 5. Assignee
+        $users = $this->jiraClient->getAssignableUsers($projectKey);
+        $currentAssigneeName = $issue['fields']['assignee']['displayName'] ?? 'Unassigned';
+        if (!empty($users)) {
+            $userChoices = ['unassigned' => 'Unassigned'];
+            $defaultIndex = 'unassigned';
+            foreach ($users as $index => $u) {
+                $displayName = $u['displayName'] ?? $u['emailAddress'] ?? $u['accountId'];
+                $userChoices[$index] = $displayName;
+                if (isset($issue['fields']['assignee']['accountId']) && $u['accountId'] === $issue['fields']['assignee']['accountId']) {
+                    $defaultIndex = $index;
+                }
+            }
+
+            $question = new ChoiceQuestion("Select Assignee [{$currentAssigneeName}]: ", $userChoices, $defaultIndex);
+            $selectedUserKey = $this->questionHelper->ask($input, $output, $question);
+            if ($selectedUserKey === 'unassigned') {
+                if ($currentAssigneeName !== 'Unassigned') {
+                    $payload['fields']['assignee'] = null;
+                }
+            } else {
+                $selectedUser = $users[$selectedUserKey] ?? null;
+                if ($selectedUser && ($selectedUser['displayName'] !== $currentAssigneeName)) {
+                    $payload['fields']['assignee'] = ['accountId' => $selectedUser['accountId']];
+                }
+            }
+        }
+
+        // 6. Epic
+        $epics = $this->jiraClient->getEpics($projectKey);
+        $currentEpicKey = $issue['fields']['parent']['key'] ?? 'None';
+        if (!empty($epics)) {
+            $epicChoices = ['none' => 'None (no epic)'];
+            $defaultIndex = 'none';
+            foreach ($epics as $e) {
+                $epicChoices[$e['key']] = "{$e['key']} - {$e['fields']['summary']}";
+                if ($e['key'] === $currentEpicKey) {
+                    $defaultIndex = $e['key'];
+                }
+            }
+
+            $question = new ChoiceQuestion("Select Epic [{$currentEpicKey}]: ", $epicChoices, $defaultIndex);
+            $selectedEpic = $this->questionHelper->ask($input, $output, $question);
+            if ($selectedEpic === 'none') {
+                if ($currentEpicKey !== 'None') {
+                    $payload['fields']['parent'] = null;
+                }
+            } elseif ($selectedEpic !== $currentEpicKey) {
+                $payload['fields']['parent'] = ['key' => $selectedEpic];
+            }
+        }
+
+        // 7. Labels
+        $currentLabels = isset($issue['fields']['labels']) ? implode(', ', $issue['fields']['labels']) : '';
+        $question = new Question("Labels (comma separated) [{$currentLabels}]: ", $currentLabels);
+        $labelsRaw = $this->questionHelper->ask($input, $output, $question);
+        if ($labelsRaw !== $currentLabels) {
+            $payload['fields']['labels'] = array_values(array_filter(array_map('trim', explode(',', $labelsRaw))));
+        }
+
+        // 8. Sprint
+        $sprint = $this->jiraClient->getActiveSprint($projectKey);
+        if ($sprint) {
+            $question = new Question("Add to active sprint '{$sprint['name']}'? (y/N): ", 'n');
+            $addToSprint = $this->questionHelper->ask($input, $output, $question);
+            if (strtolower($addToSprint) === 'y') {
+                $payload['sprint_id'] = (int) $sprint['id'];
+            }
+        }
+
+        return $payload;
+    }
+}

--- a/src/JiraApiClient.php
+++ b/src/JiraApiClient.php
@@ -209,6 +209,37 @@ class JiraApiClient
     }
 
     /**
+     * Upload an attachment to an issue.
+     */
+    public function uploadAttachment(string $issueKey, string $filePath): array
+    {
+        try {
+            if (!file_exists($filePath)) {
+                throw new \InvalidArgumentException("File not found: {$filePath}");
+            }
+
+            $response = $this->client->post("/rest/api/3/issue/{$issueKey}/attachments", [
+                'headers' => [
+                    'X-Atlassian-Token' => 'no-check',
+                    'Content-Type' => null,
+                ],
+                'multipart' => [
+                    [
+                        'name' => 'file',
+                        'contents' => fopen($filePath, 'r'),
+                        'filename' => basename($filePath),
+                    ]
+                ],
+            ]);
+
+            return json_decode($response->getBody()->getContents(), true);
+        } catch (RequestException $e) {
+            $errorBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : '';
+            throw new \Exception("Failed to upload attachment to {$issueKey}: " . $e->getMessage() . "\nResponse: " . $errorBody);
+        }
+    }
+
+    /**
      * Get issue by key.
      */
     public function getIssue(string $issueKey): ?array

--- a/src/JiraApiClient.php
+++ b/src/JiraApiClient.php
@@ -244,4 +244,21 @@ class JiraApiClient
             return false;
         }
     }
+
+    /**
+     * Update an existing issue.
+     */
+    public function updateIssue(string $issueKey, array $issueData): bool
+    {
+        try {
+            $response = $this->client->put("/rest/api/3/issue/{$issueKey}", [
+                'json' => $issueData,
+            ]);
+
+            return $response->getStatusCode() === 204;
+        } catch (RequestException $e) {
+            $errorBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : '';
+            throw new \Exception("Failed to update issue {$issueKey}: " . $e->getMessage() . "\nResponse: " . $errorBody);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a new `update` command to allow users to modify fields on existing Jira tickets, and introduces support for uploading files and images as attachments in `create`, `create-from`, and `update` commands.

### Features:

* **Update Command:**
  * Supported Fields: `summary`, `description`, `type` (issue type), `epic`/`parent`, `priority`, `assignee`, `labels`, and `sprint`.
  * Interactive Mode: If run interactively, the wizard guides you through each field, displaying the current value in brackets as the default.
  * Non-Interactive Mode: Update specific fields directly from the command line using options.
  * Dry Run: Includes a `--dry-run` flag to preview the generated API payload without modifying the ticket.

* **Attachments Upload:**
  * Support uploading files and images (e.g., screenshots of bugs) to Jira issues using the `--attachment` / `-a` option in `create`, `create-from`, and `update` commands.
  * Interactive Wizard Support: The wizard now includes a step/prompt asking for files to attach to the ticket (validating if they exist in disk).
  * Uploads attachments immediately after ticket creation or modification.

### Changes:

* Added `update` command to the Symfony console application registration in `bin/jira-wizard`.
* Added `updateIssue` method to `JiraApiClient.php` using a `PUT` request to `/rest/api/3/issue/{key}`.
* Created `UpdateCommand.php` command class.
* Added `uploadAttachment` method to `JiraApiClient.php` using a `multipart` request to `/rest/api/3/issue/{key}/attachments`.
* Modified `CreateTicketCommand.php`, `CreateFromCommand.php`, and `UpdateCommand.php` to support `--attachment` option and prompt interactively for files.
